### PR TITLE
Use STRING_SPLIT for parameterized IN clauses in SqlServer store

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
@@ -99,6 +99,10 @@ public class StoreTests : TestTemplates.StoreTests
         => RestartingFunctionShouldSetInterruptedToFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
+    public override Task ResetInterruptedClearsInterruptedFlag()
+        => ResetInterruptedClearsInterruptedFlag(FunctionStoreFactory.Create());
+
+    [TestMethod]
     public override Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated()
         => MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated(FunctionStoreFactory.Create());
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -689,14 +689,14 @@ public abstract class StoreTests
         session.ShouldBeNull();
 
         await store.Interrupt(functionId).ShouldBeTrueAsync();
-        await store.Interrupted(functionId).ShouldBeAsync(true);
+        (await store.GetInterruptedFunctions()).Any(id => id == functionId).ShouldBeTrue();
 
         await store.RestartExecution(
-            functionId, 
+            functionId,
             owner: ReplicaId.NewId()
         ).ShouldNotBeNullAsync();
-       
-        await store.Interrupted(functionId).ShouldBeAsync(false);
+
+        (await store.GetInterruptedFunctions()).Any(id => id == functionId).ShouldBeFalse();
     }
     
     public abstract Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated();
@@ -1039,7 +1039,7 @@ public abstract class StoreTests
     {
         var functionId = TestStoredId.Create();
         var store = await storeTask;
-        (await store.Interrupted(functionId)).ShouldBeNull();
+        (await store.GetFunction(functionId)).ShouldBeNull();
     }
     
     public abstract Task DefaultStateCanSetAndFetchedAfterwards();

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -698,7 +698,49 @@ public abstract class StoreTests
 
         (await store.GetInterruptedFunctions()).Any(id => id == functionId).ShouldBeFalse();
     }
-    
+
+    public abstract Task ResetInterruptedClearsInterruptedFlag();
+    protected async Task ResetInterruptedClearsInterruptedFlag(Task<IFunctionStore> storeTask)
+    {
+        var store = await storeTask;
+        var functionId1 = TestStoredId.Create();
+        var functionId2 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
+
+        await store.CreateFunction(
+            functionId1,
+            "humanInstanceId1",
+            param: Test.SimpleStoredParameter,
+            leaseExpiration: DateTime.UtcNow.Ticks,
+            postponeUntil: null,
+            timestamp: DateTime.UtcNow.Ticks,
+            parent: null,
+            owner: null
+        );
+
+        await store.CreateFunction(
+            functionId2,
+            "humanInstanceId2",
+            param: Test.SimpleStoredParameter,
+            leaseExpiration: DateTime.UtcNow.Ticks,
+            postponeUntil: null,
+            timestamp: DateTime.UtcNow.Ticks,
+            parent: null,
+            owner: null
+        );
+
+        await store.Interrupt(functionId1).ShouldBeTrueAsync();
+        await store.Interrupt(functionId2).ShouldBeTrueAsync();
+
+        (await store.GetInterruptedFunctions()).Count.ShouldBe(2);
+
+        await store.ResetInterrupted([functionId1]);
+
+        var interrupted = await store.GetInterruptedFunctions();
+        interrupted.Count.ShouldBe(1);
+        interrupted.Any(id => id == functionId2).ShouldBeTrue();
+        interrupted.Any(id => id == functionId1).ShouldBeFalse();
+    }
+
     public abstract Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated();
     public async Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated(Task<IFunctionStore> storeTask)
     {

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
@@ -189,11 +189,6 @@ public class CrashableFunctionStore : IFunctionStore
 
     public Task ResetInterrupted(IReadOnlyList<StoredId> storedIds) => _inner.ResetInterrupted(storedIds);
 
-    public Task<bool?> Interrupted(StoredId storedId) 
-        => _crashed
-            ? Task.FromException<bool?>(new TimeoutException())
-            : _inner.Interrupted(storedId);
-    
     public Task<bool> SetParameters(StoredId storedId, byte[]? storedParameter, byte[]? storedResult, ReplicaId? expectedReplica)
         => _crashed
             ? Task.FromException<bool>(new TimeoutException())

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
@@ -187,6 +187,8 @@ public class CrashableFunctionStore : IFunctionStore
 
     public Task Interrupt(IReadOnlyList<StoredId> storedIds) => _inner.Interrupt(storedIds);
 
+    public Task ResetInterrupted(IReadOnlyList<StoredId> storedIds) => _inner.ResetInterrupted(storedIds);
+
     public Task<bool?> Interrupted(StoredId storedId) 
         => _crashed
             ? Task.FromException<bool?>(new TimeoutException())

--- a/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
@@ -104,7 +104,8 @@ public interface IFunctionStore
 
     Task<bool> Interrupt(StoredId storedId);
     Task Interrupt(IReadOnlyList<StoredId> storedIds);
-    Task<bool?> Interrupted(StoredId storedId); 
+    Task ResetInterrupted(IReadOnlyList<StoredId> storedIds);
+    Task<bool?> Interrupted(StoredId storedId);
 
     Task<Status?> GetFunctionStatus(StoredId storedId);
     Task<IReadOnlyList<StatusAndId>> GetFunctionsStatus(IEnumerable<StoredId> storedIds);

--- a/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
@@ -105,7 +105,6 @@ public interface IFunctionStore
     Task<bool> Interrupt(StoredId storedId);
     Task Interrupt(IReadOnlyList<StoredId> storedIds);
     Task ResetInterrupted(IReadOnlyList<StoredId> storedIds);
-    Task<bool?> Interrupted(StoredId storedId);
 
     Task<Status?> GetFunctionStatus(StoredId storedId);
     Task<IReadOnlyList<StatusAndId>> GetFunctionsStatus(IEnumerable<StoredId> storedIds);

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -450,6 +450,18 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
             await Interrupt(storedId);
     }
 
+    public Task ResetInterrupted(IReadOnlyList<StoredId> storedIds)
+    {
+        lock (_sync)
+        {
+            foreach (var storedId in storedIds)
+                if (_states.TryGetValue(storedId, out var state))
+                    state.Interrupted = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task<bool?> Interrupted(StoredId storedId)
     {
         lock (_sync)

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -462,17 +462,6 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         return Task.CompletedTask;
     }
 
-    public Task<bool?> Interrupted(StoredId storedId)
-    {
-        lock (_sync)
-        {
-            if (!_states.ContainsKey(storedId))
-                return Task.FromResult(default(bool?));
-
-            return ((bool?) _states[storedId].Interrupted).ToTask();
-        }
-    }
-
     public Task<Status?> GetFunctionStatus(StoredId storedId)
     {
         lock (_sync)

--- a/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
+++ b/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
@@ -175,11 +175,6 @@ public class CrashableFunctionStore : IFunctionStore
             ? Task.FromException(new TimeoutException())
             : _inner.ResetInterrupted(storedIds);
 
-    public Task<bool?> Interrupted(StoredId storedId)
-        => _crashed
-            ? Task.FromException<bool?>(new TimeoutException())
-            : _inner.Interrupted(storedId);
-    
     public Task<Status?> GetFunctionStatus(StoredId storedId)
         => _crashed
             ? Task.FromException<Status?>(new TimeoutException())

--- a/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
+++ b/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
@@ -170,6 +170,11 @@ public class CrashableFunctionStore : IFunctionStore
             ? Task.FromException(new TimeoutException())
             : _inner.Interrupt(storedIds);
 
+    public Task ResetInterrupted(IReadOnlyList<StoredId> storedIds)
+        => _crashed
+            ? Task.FromException(new TimeoutException())
+            : _inner.ResetInterrupted(storedIds);
+
     public Task<bool?> Interrupted(StoredId storedId)
         => _crashed
             ? Task.FromException<bool?>(new TimeoutException())

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
@@ -88,6 +88,10 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => RestartingFunctionShouldSetInterruptedToFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
+    public override Task ResetInterruptedClearsInterruptedFlag()
+        => ResetInterruptedClearsInterruptedFlag(FunctionStoreFactory.Create());
+
+    [TestMethod]
     public override Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated()
         => MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated(FunctionStoreFactory.Create());
 

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -670,9 +670,19 @@ public class MariaDbFunctionStore : IFunctionStore
     {
         if (storedIds.Count == 0)
             return;
-        
+
         await using var conn = await CreateOpenConnection(_connectionString);
         await using var cmd = _sqlGenerator.Interrupt(storedIds).ToSqlCommand(conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task ResetInterrupted(IReadOnlyList<StoredId> storedIds)
+    {
+        if (storedIds.Count == 0)
+            return;
+
+        await using var conn = await CreateOpenConnection(_connectionString);
+        await using var cmd = _sqlGenerator.ResetInterrupted(storedIds).ToSqlCommand(conn);
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -719,26 +719,6 @@ public class MariaDbFunctionStore : IFunctionStore
         return affectedRows == 1;
     }
 
-    private string? _getInterruptCountSql;
-    public async Task<bool?> Interrupted(StoredId storedId)
-    {
-        await using var conn = await CreateOpenConnection(_connectionString);
-        
-        _getInterruptCountSql ??= $@"
-            SELECT interrupted 
-            FROM {_tablePrefix}
-            WHERE id = ?;";
-
-        await using var command = new MySqlCommand(_getInterruptCountSql, conn)
-        {
-            Parameters =
-            {
-                new() { Value = storedId.AsGuid.ToString("N") },
-            }
-        };
-        
-        return (bool?) await command.ExecuteScalarAsync();
-    }
 
     private string? _getFunctionStatusSql;
     public async Task<Status?> GetFunctionStatus(StoredId storedId)

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -33,7 +33,17 @@ public class SqlGenerator(string tablePrefix)
 
         return StoreCommand.Create(sql);
     }
-    
+
+    public StoreCommand ResetInterrupted(IEnumerable<StoredId> storedIds)
+    {
+        var sql = @$"
+                UPDATE {tablePrefix}
+                SET interrupted = FALSE
+                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid:N}'").StringJoin(", ")});";
+
+        return StoreCommand.Create(sql);
+    }
+
     private string? _getEffectResultsSql;
     public StoreCommand GetEffects(StoredId storedId)
     {

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
@@ -91,6 +91,10 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => RestartingFunctionShouldSetInterruptedToFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
+    public override Task ResetInterruptedClearsInterruptedFlag()
+        => ResetInterruptedClearsInterruptedFlag(FunctionStoreFactory.Create());
+
+    [TestMethod]
     public override Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated()
         => MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated(FunctionStoreFactory.Create());
     

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
@@ -684,24 +684,6 @@ public class PostgreSqlFunctionStore : IFunctionStore
         await command.ExecuteNonQueryAsync();
     }
 
-    private string? _interruptedSql;
-    public async Task<bool?> Interrupted(StoredId storedId)
-    {
-        await using var conn = await CreateConnection();
-
-        _interruptedSql ??= $@"
-                SELECT interrupted 
-                FROM {_tableName}
-                WHERE id = $1";
-        await using var command = new NpgsqlCommand(_interruptedSql, conn)
-        {
-            Parameters =
-            {
-                new() { Value = storedId.AsGuid },
-            }
-        };
-        return (bool?) await command.ExecuteScalarAsync();
-    }
 
     private string? _getFunctionStatusSql;
     public async Task<Status?> GetFunctionStatus(StoredId storedId)

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
@@ -668,9 +668,19 @@ public class PostgreSqlFunctionStore : IFunctionStore
     {
         if (storedIds.Count == 0)
             return;
-        
+
         await using var conn = await CreateConnection();
         await using var command = _sqlGenerator.Interrupt(storedIds).ToNpgsqlCommand(conn);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task ResetInterrupted(IReadOnlyList<StoredId> storedIds)
+    {
+        if (storedIds.Count == 0)
+            return;
+
+        await using var conn = await CreateConnection();
+        await using var command = _sqlGenerator.ResetInterrupted(storedIds).ToNpgsqlCommand(conn);
         await command.ExecuteNonQueryAsync();
     }
 

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -37,7 +37,17 @@ public class SqlGenerator(string tablePrefix)
 
         return StoreCommand.Create(sql, values: [ storedIds.Select(id => id.AsGuid).ToArray() ]);
     }
-    
+
+    public StoreCommand ResetInterrupted(IEnumerable<StoredId> storedIds)
+    {
+        var sql = @$"
+                UPDATE {tablePrefix}
+                SET interrupted = FALSE
+                WHERE Id = ANY($1)";
+
+        return StoreCommand.Create(sql, values: [ storedIds.Select(id => id.AsGuid).ToArray() ]);
+    }
+
     private string? _getEffectResultsSql;
     public StoreCommand GetEffects(StoredId storedId)
     {

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
@@ -91,6 +91,10 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => RestartingFunctionShouldSetInterruptedToFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
+    public override Task ResetInterruptedClearsInterruptedFlag()
+        => ResetInterruptedClearsInterruptedFlag(FunctionStoreFactory.Create());
+
+    [TestMethod]
     public override Task MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated()
         => MessagesCanBeFetchedAfterFunctionWithInitialMessagesHasBeenCreated(FunctionStoreFactory.Create());
     

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -38,7 +38,17 @@ public class SqlGenerator(string tablePrefix)
 
         return StoreCommand.Create(sql);
     }
-    
+
+    public StoreCommand ResetInterrupted(IEnumerable<StoredId> storedIds)
+    {
+        var sql = @$"
+                UPDATE {tablePrefix}
+                SET Interrupted = 0
+                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid}'").StringJoin(", ")});";
+
+        return StoreCommand.Create(sql);
+    }
+
     public StoreCommand InsertEffects(StoredId storedId, IReadOnlyList<StoredEffectChange> changes, SnapshotStorageSession session, string paramPrefix)
     {
         foreach (var change in changes)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -17,36 +17,42 @@ namespace Cleipnir.ResilientFunctions.SqlServer;
 
 public class SqlGenerator(string tablePrefix)
 {
+    private string? _interruptSql;
     public StoreCommand Interrupt(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _interruptSql ??= @$"
                 UPDATE {tablePrefix}
-                SET 
+                SET
                     Interrupted = 1,
-                    Status = 
-                        CASE 
+                    Status =
+                        CASE
                             WHEN Status = {(int)Status.Suspended} THEN {(int)Status.Postponed}
                             ELSE Status
                         END,
-                    Expires = 
+                    Expires =
                         CASE
                             WHEN Status = {(int)Status.Postponed} THEN 0
                             WHEN Status = {(int)Status.Suspended} THEN 0
                             ELSE Expires
                         END
-                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid}'").StringJoin(", ")});";
+                WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','));";
 
-        return StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_interruptSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
+        return command;
     }
 
+    private string? _resetInterruptedSql;
     public StoreCommand ResetInterrupted(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _resetInterruptedSql ??= @$"
                 UPDATE {tablePrefix}
                 SET Interrupted = 0
-                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid}'").StringJoin(", ")});";
+                WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','));";
 
-        return StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_resetInterruptedSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
+        return command;
     }
 
     public StoreCommand InsertEffects(StoredId storedId, IReadOnlyList<StoredEffectChange> changes, SnapshotStorageSession session, string paramPrefix)
@@ -118,14 +124,16 @@ public class SqlGenerator(string tablePrefix)
         return new StoredEffectsWithSession(effects, session);
     }
     
+    private string? _getEffectsBulkSql;
     public StoreCommand GetEffects(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _getEffectsBulkSql ??= @$"
             SELECT Id, Effects
             FROM {tablePrefix}
-            WHERE Id IN ({storedIds.InClause()})";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))";
 
-        var command = StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_getEffectsBulkSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
         return command;
     }
 
@@ -467,11 +475,11 @@ public class SqlGenerator(string tablePrefix)
                    inserted.Parent,
                    inserted.Owner,
                    inserted.Effects
-            WHERE Id IN ({{0}}) AND Owner IS NULL;";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ',')) AND Owner IS NULL;";
 
-        var sql = string.Format(_restartExecutionsSql, storedIds.InClause());
-        var storeCommand = StoreCommand.Create(sql);
+        var storeCommand = StoreCommand.Create(_restartExecutionsSql);
         storeCommand.AddParameter("@Owner", replicaId.AsGuid);
+        storeCommand.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
 
         return storeCommand;
     }
@@ -637,15 +645,17 @@ public class SqlGenerator(string tablePrefix)
         return messages;
     }
     
+    private string? _getMessagesBulkSql;
     public StoreCommand GetMessages(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _getMessagesBulkSql ??= @$"
             SELECT Id, Position, Content
             FROM {tablePrefix}_Messages
-            WHERE Id IN ({storedIds.InClause()})
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))
             ORDER BY Position;";
 
-        var command = StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_getMessagesBulkSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
         return command;
     }
     

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerEffectsStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerEffectsStore.cs
@@ -87,9 +87,10 @@ public class SqlServerEffectsStore(string connectionString, string tablePrefix =
         var sql = @$"
             SELECT Id, Effects
             FROM {_tableName}
-            WHERE Id IN ({storedIdsList.InClause()})";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))";
 
         var command = StoreCommand.Create(sql);
+        command.AddParameter("@Ids", storedIdsList.ToCommaSeparatedIds());
         await using var reader = await _commandExecutor.Execute(command);
 
         foreach (var storedId in storedIdsList)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
@@ -772,22 +772,7 @@ public class SqlServerFunctionStore : IFunctionStore
         var affectedRows = await command.ExecuteNonQueryAsync();
         return affectedRows > 0;
     }
-    
-    private string? _interruptedSql;
-    public async Task<bool?> Interrupted(StoredId storedId)
-    {
-        await using var conn = await _connFunc();
-        _interruptedSql ??= @$"
-                SELECT Interrupted 
-                FROM {_tableName}            
-                WHERE Id = @Id;";
 
-        await using var command = new SqlCommand(_interruptedSql, conn);
-        command.Parameters.AddWithValue("@Id", storedId.AsGuid);
-
-        var interrupted = await command.ExecuteScalarAsync();
-        return (bool?) interrupted;
-    }
 
     private string? _getFunctionStatusSql;
     public async Task<Status?> GetFunctionStatus(StoredId storedId)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
@@ -730,9 +730,19 @@ public class SqlServerFunctionStore : IFunctionStore
     {
         if (storedIds.Count == 0)
             return;
-        
+
         await using var conn = await _connFunc();
         await using var cmd = _sqlGenerator.Interrupt(storedIds).ToSqlCommand(conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task ResetInterrupted(IReadOnlyList<StoredId> storedIds)
+    {
+        if (storedIds.Count == 0)
+            return;
+
+        await using var conn = await _connFunc();
+        await using var cmd = _sqlGenerator.ResetInterrupted(storedIds).ToSqlCommand(conn);
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -247,11 +247,12 @@ public class SqlServerMessageStore : IMessageStore
         var sql = @$"
             SELECT Id, MAX(Position)
             FROM {_tablePrefix}_Messages
-            WHERE Id IN ({storedIds.Select(id => $"'{id}'").StringJoin(", ")})
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))
             GROUP BY Id;";
 
         await using var conn = await CreateConnection();
         await using var command = new SqlCommand(sql, conn);
+        command.Parameters.AddWithValue("@Ids", storedIds.ToCommaSeparatedIds());
 
         var positions = new Dictionary<StoredId, long>(capacity: storedIds.Count);
         foreach (var storedId in storedIds)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/StoreCommandExtensions.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/StoreCommandExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Cleipnir.ResilientFunctions.Storage;
 using Microsoft.Data.SqlClient;
 
@@ -28,6 +29,12 @@ internal static class StoreCommandExtensions
 
     public static SqlBatch ToSqlBatch(this IEnumerable<StoreCommand> commands) => commands.CreateBatch();
     public static SqlBatch ToSqlBatch(this StoreCommands commands) => commands.Commands.CreateBatch();
+}
+
+internal static class StoredIdExtensions
+{
+    public static string ToCommaSeparatedIds(this IEnumerable<StoredId> storedIds)
+        => string.Join(",", storedIds.Select(id => id.AsGuid));
 }
 
 internal static class StoreCommandsHelper


### PR DESCRIPTION
## Summary
- Replace inline GUID string concatenation in SQL `IN` clauses with `STRING_SPLIT(@Ids, ',')` parameter across all SqlServer bulk query methods
- Add `ToCommaSeparatedIds()` helper extension for converting `IEnumerable<StoredId>` to a comma-separated string
- Enable SQL query plan reuse regardless of list size (single cached SQL string per method)
- Affected methods: `Interrupt`, `ResetInterrupted`, `GetEffects` (bulk), `RestartExecutions`, `GetMessages` (bulk), `GetMaxPositions`

## Test plan
- [ ] Run SqlServer test suite to verify all bulk operations still work correctly
- [ ] Verify `RestartExecutions`, `Interrupt`, and message/effect bulk fetches pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)