### PR TITLE
Use STRING_SPLIT for parameterized IN clauses in SqlServer store

### DIFF
--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -17,36 +17,42 @@ namespace Cleipnir.ResilientFunctions.SqlServer;
 
 public class SqlGenerator(string tablePrefix)
 {
+    private string? _interruptSql;
     public StoreCommand Interrupt(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _interruptSql ??= @$"
                 UPDATE {tablePrefix}
-                SET 
+                SET
                     Interrupted = 1,
-                    Status = 
-                        CASE 
+                    Status =
+                        CASE
                             WHEN Status = {(int)Status.Suspended} THEN {(int)Status.Postponed}
                             ELSE Status
                         END,
-                    Expires = 
+                    Expires =
                         CASE
                             WHEN Status = {(int)Status.Postponed} THEN 0
                             WHEN Status = {(int)Status.Suspended} THEN 0
                             ELSE Expires
                         END
-                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid}'").StringJoin(", ")});";
+                WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','));";
 
-        return StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_interruptSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
+        return command;
     }
 
+    private string? _resetInterruptedSql;
     public StoreCommand ResetInterrupted(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _resetInterruptedSql ??= @$"
                 UPDATE {tablePrefix}
                 SET Interrupted = 0
-                WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid}'").StringJoin(", ")});";
+                WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','));";
 
-        return StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_resetInterruptedSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
+        return command;
     }
 
     public StoreCommand InsertEffects(StoredId storedId, IReadOnlyList<StoredEffectChange> changes, SnapshotStorageSession session, string paramPrefix)
@@ -118,14 +124,16 @@ public class SqlGenerator(string tablePrefix)
         return new StoredEffectsWithSession(effects, session);
     }
     
+    private string? _getEffectsBulkSql;
     public StoreCommand GetEffects(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _getEffectsBulkSql ??= @$"
             SELECT Id, Effects
             FROM {tablePrefix}
-            WHERE Id IN ({storedIds.InClause()})";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))";
 
-        var command = StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_getEffectsBulkSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
         return command;
     }
 
@@ -467,11 +475,11 @@ public class SqlGenerator(string tablePrefix)
                    inserted.Parent,
                    inserted.Owner,
                    inserted.Effects
-            WHERE Id IN ({{0}}) AND Owner IS NULL;";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ',')) AND Owner IS NULL;";
 
-        var sql = string.Format(_restartExecutionsSql, storedIds.InClause());
-        var storeCommand = StoreCommand.Create(sql);
+        var storeCommand = StoreCommand.Create(_restartExecutionsSql);
         storeCommand.AddParameter("@Owner", replicaId.AsGuid);
+        storeCommand.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
 
         return storeCommand;
     }
@@ -637,15 +645,17 @@ public class SqlGenerator(string tablePrefix)
         return messages;
     }
     
+    private string? _getMessagesBulkSql;
     public StoreCommand GetMessages(IEnumerable<StoredId> storedIds)
     {
-        var sql = @$"
+        _getMessagesBulkSql ??= @$"
             SELECT Id, Position, Content
             FROM {tablePrefix}_Messages
-            WHERE Id IN ({storedIds.InClause()})
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))
             ORDER BY Position;";
 
-        var command = StoreCommand.Create(sql);
+        var command = StoreCommand.Create(_getMessagesBulkSql);
+        command.AddParameter("@Ids", storedIds.ToCommaSeparatedIds());
         return command;
     }
     

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerEffectsStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerEffectsStore.cs
@@ -87,9 +87,10 @@ public class SqlServerEffectsStore(string connectionString, string tablePrefix =
         var sql = @$"
             SELECT Id, Effects
             FROM {_tableName}
-            WHERE Id IN ({storedIdsList.InClause()})";
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))";
 
         var command = StoreCommand.Create(sql);
+        command.AddParameter("@Ids", storedIdsList.ToCommaSeparatedIds());
         await using var reader = await _commandExecutor.Execute(command);
 
         foreach (var storedId in storedIdsList)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -131,6 +131,8 @@ public class SqlServerMessageStore : IMessageStore
             command.Parameters.AddWithValue($"@Position{i}", position);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
+        foreach (var (value, name) in interuptsSql.Parameters)
+            command.Parameters.AddWithValue(name, value);
 
         await command.ExecuteNonQueryAsync();
     }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -247,11 +247,12 @@ public class SqlServerMessageStore : IMessageStore
         var sql = @$"
             SELECT Id, MAX(Position)
             FROM {_tablePrefix}_Messages
-            WHERE Id IN ({storedIds.Select(id => $"'{id}'").StringJoin(", ")})
+            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))
             GROUP BY Id;";
 
         await using var conn = await CreateConnection();
         await using var command = new SqlCommand(sql, conn);
+        command.Parameters.AddWithValue("@Ids", storedIds.ToCommaSeparatedIds());
 
         var positions = new Dictionary<StoredId, long>(capacity: storedIds.Count);
         foreach (var storedId in storedIds)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/StoreCommandExtensions.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/StoreCommandExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Cleipnir.ResilientFunctions.Storage;
 using Microsoft.Data.SqlClient;
 
@@ -28,6 +29,12 @@ internal static class StoreCommandExtensions
 
     public static SqlBatch ToSqlBatch(this IEnumerable<StoreCommand> commands) => commands.CreateBatch();
     public static SqlBatch ToSqlBatch(this StoreCommands commands) => commands.Commands.CreateBatch();
+}
+
+internal static class StoredIdExtensions
+{
+    public static string ToCommaSeparatedIds(this IEnumerable<StoredId> storedIds)
+        => string.Join(",", storedIds.Select(id => id.AsGuid));
 }
 
 internal static class StoreCommandsHelper


### PR DESCRIPTION
## Summary
- Replace inline GUID string concatenation in SQL `IN` clauses with `STRING_SPLIT(@Ids, ',')` parameter across all SqlServer bulk query methods
- Add `ToCommaSeparatedIds()` helper extension for converting `IEnumerable<StoredId>` to a comma-separated string
- Enable SQL query plan reuse regardless of list size (single cached SQL string per method)
- Affected methods: `Interrupt`, `ResetInterrupted`, `GetEffects` (bulk), `RestartExecutions`, `GetMessages` (bulk), `GetMaxPositions`

## Test plan
- [ ] Run SqlServer test suite to verify all bulk operations still work correctly
- [ ] Verify `RestartExecutions`, `Interrupt`, and message/effect bulk fetches pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)