### PR TITLE
Add IFunctionStore to FlowsManager and reset interrupted on interrupt

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -569,7 +569,7 @@ public abstract class MessagesSubscriptionTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -630,7 +630,7 @@ public abstract class MessagesSubscriptionTests
                     minimumTimeout,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -687,7 +687,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -44,7 +44,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 queueClient = await queueManager.CreateQueueClient();
@@ -94,10 +94,10 @@ public abstract class MessagesTests
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
-                var flowsManager = new FlowsManager(() => DateTime.UtcNow);
+                var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
                 flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId(), TimeSpan.FromMilliseconds(100));
@@ -141,10 +141,10 @@ public abstract class MessagesTests
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
-                var flowsManager = new FlowsManager(() => DateTime.UtcNow);
+                var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
                 flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
@@ -192,7 +192,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -242,7 +242,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -293,7 +293,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -346,7 +346,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -397,7 +397,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default with { MessagesDefaultMaxWaitForCompletion = TimeSpan.FromMinutes(1) },
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -460,7 +460,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -525,7 +525,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();
@@ -552,7 +552,7 @@ public abstract class MessagesTests
                     new FlowTimeouts(),
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default,
-                    new FlowsManager(() => DateTime.UtcNow)
+                    new FlowsManager(functionStore, () => DateTime.UtcNow)
                 );
 
                 var queueClient = await queueManager.CreateQueueClient();

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
@@ -332,7 +332,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store, () => DateTime.UtcNow), storedId);
 
         effect.TryGet<int>("alias", out _).ShouldBeFalse();
 
@@ -380,7 +380,7 @@ public abstract class EffectTests
             storageSession: null,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store, () => DateTime.UtcNow), storedId);
 
         // Verify the effect is immediately available (eager loading)
         effect.TryGet<int>("test_alias", out var result).ShouldBeTrue();
@@ -714,7 +714,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store, () => DateTime.UtcNow), storedId);
 
         var result = await effect.Capture(() => "hello world", ResiliencyLevel.AtLeastOnceDelayFlush);
         result.ShouldBe("hello world");

--- a/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
@@ -43,7 +43,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1]\n";
@@ -75,7 +75,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1] my-effect\n";
@@ -111,7 +111,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✗ [1] failed-operation (System.InvalidOperationException)\n";
@@ -143,7 +143,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ⋯ [1] in-progress\n";
@@ -189,7 +189,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -245,7 +245,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -295,7 +295,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -330,7 +330,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -365,7 +365,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -398,7 +398,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(() => DateTime.UtcNow), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore(), () => DateTime.UtcNow), storedId);
         var output = effect.ExecutionTree();
 
         var expected =

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -13,11 +13,13 @@ public class FlowsManager : IDisposable
 {
     private readonly Dictionary<StoredId, FlowState> _dict = new();
     private readonly Lock _lock = new();
+    private readonly IFunctionStore _functionStore;
     private readonly UtcNow _utcNow;
     private volatile bool _disposed;
 
-    public FlowsManager(UtcNow utcNow)
+    public FlowsManager(IFunctionStore functionStore, UtcNow utcNow)
     {
+        _functionStore = functionStore;
         _utcNow = utcNow;
         _ = Task.Run(TimeoutCheckLoop);
     }
@@ -54,20 +56,19 @@ public class FlowsManager : IDisposable
             _dict.Remove(id);
     }
 
-    public void Interrupt(IEnumerable<StoredId> ids)
+    public async Task Interrupt(IReadOnlyList<StoredId> ids)
     {
+        await _functionStore.ResetInterrupted(ids);
+        
         lock (_lock)
-        {
             foreach (var id in ids)
             {
                 if (!_dict.TryGetValue(id, out var flowState))
                     continue;
-
+                
                 flowState.Interrupt();
                 Task.Run(() => flowState.QueueManager.FetchMessagesOnce());
             }
-
-        }
     }
 
     public void StartThread(StoredId id)

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -40,7 +40,7 @@ public class FunctionsRegistry : IDisposable
         _shutdownCoordinator = new ShutdownCoordinator();
         _settings = SettingsWithDefaults.Default.Merge(settings);
         var utcNow = _settings.UtcNow;
-        _flowsManager = new FlowsManager(utcNow);
+        _flowsManager = new FlowsManager(_functionStore, utcNow);
         
         ClusterInfo = new ClusterInfo(ReplicaId.NewId());
         


### PR DESCRIPTION
## Summary
- Add `IFunctionStore` as a constructor dependency to `FlowsManager`
- Call `ResetInterrupted` in `FlowsManager.Interrupt()` to persist the interrupt reset to the store
- Change `Interrupt` signature from `void` to `async Task` and parameter from `IEnumerable` to `IReadOnlyList`
- Update all test call sites to pass the function store

## Test plan
- [x] Solution builds with 0 errors, 0 warnings
- [ ] Run core tests
- [ ] Run database-specific store tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)