### PR TITLE
Replace SignalSuspendedToInvoker callback with SuspendedTask

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -574,7 +574,7 @@ public abstract class MessagesSubscriptionTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message = await queueClient.Pull<GoodMessage>(
@@ -637,7 +637,7 @@ public abstract class MessagesSubscriptionTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, minimumTimeout);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,minimumTimeout);
 
                 var queueClient = await queueManager.CreateQueueClient();
 
@@ -698,7 +698,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 // Pull envelope for specific receiver

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -49,7 +49,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
 
@@ -101,7 +101,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId(), TimeSpan.FromMilliseconds(100));
 
@@ -148,7 +148,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -200,7 +200,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -253,7 +253,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(
                     workflow,
@@ -307,7 +307,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
                 var message2 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -363,7 +363,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -417,7 +417,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
                 lock (queueClients)
                     queueClients[workflow.FlowId.Instance.Value] = queueClient;
@@ -483,7 +483,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 while (true)
@@ -551,7 +551,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)
@@ -581,7 +581,7 @@ public abstract class MessagesTests
                     flowsManager
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, () => { }, queueManager, flowTimeouts);
+                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Helpers;
@@ -7,33 +6,33 @@ using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
 
-internal class FlowState
+public class FlowState
 {
     private readonly Lock _lock = new();
+    private readonly TaskCompletionSource _suspendedTcs = new();
 
     public StoredId Id { get; }
-    public Action SignalSuspendedToInvoker { get; }
     public QueueManager QueueManager { get; }
     public int Threads { get; private set; }
     public int SuspendedThreads { get; private set; }
     public FlowTimeouts Timeouts { get; }
     public AsyncSignal InterruptSignal { get; } = new();
     public bool Suspended { get; private set; }
+    public Task SuspendedTask { get; }
 
     public FlowState(
         StoredId id,
-        Action signalSuspendedToInvoker,
         QueueManager queueManager,
         int threads,
         int suspendedThreads,
         FlowTimeouts timeouts)
     {
         Id = id;
-        SignalSuspendedToInvoker = signalSuspendedToInvoker;
         QueueManager = queueManager;
         Threads = threads;
         SuspendedThreads = suspendedThreads;
         Timeouts = timeouts;
+        SuspendedTask = _suspendedTcs.Task;
     }
 
     public void NewThreadStarted()
@@ -83,4 +82,6 @@ internal class FlowState
         lock (_lock)
             return Threads == SuspendedThreads && (Suspended = true);
     }
+
+    public void NotifySuspension() => _suspendedTcs.TrySetResult();
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -44,10 +44,10 @@ public class FlowsManager : IDisposable
 
     public void Dispose() => _disposed = true;
 
-    public void AddFlow(StoredId id, Action suspend, QueueManager queueManager, FlowTimeouts timeouts)
+    public FlowState AddFlow(StoredId id, QueueManager queueManager, FlowTimeouts timeouts)
     {
         lock (_lock)
-            _dict[id] = new FlowState(id, suspend, queueManager, threads: 1, suspendedThreads: 0, timeouts);
+            return _dict[id] = new FlowState(id, queueManager, threads: 1, suspendedThreads: 0, timeouts);
     }
 
     public void RemoveFlow(StoredId id)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -62,12 +62,12 @@ public class Invoker<TParam, TReturn>
             return _invocationHelper.CreateInnerScheduled([flowId], parentWorkflow, detach);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(
+        var flowState = _flowsManager.AddFlow(
             storedId,
-            suspend: () => tcs.TrySetException(new InvocationSuspendedException(flowId)),
             queueManager,
             timeouts
         );
+        _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
             try
@@ -162,12 +162,12 @@ public class Invoker<TParam, TReturn>
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(
+        var flowState = _flowsManager.AddFlow(
             storedId,
-            suspend: () => tcs.TrySetException(new InvocationSuspendedException(flowId)),
             queueManager,
             timeouts
         );
+        _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
             CurrentFlow._workflow.Value = workflow;
@@ -221,12 +221,12 @@ public class Invoker<TParam, TReturn>
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(
+        var flowState = _flowsManager.AddFlow(
             storedId,
-            suspend: () => tcs.TrySetException(new InvocationSuspendedException(flowId)),
             queueManager,
             timeouts
         );
+        _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
             CurrentFlow._workflow.Value = workflow;


### PR DESCRIPTION
## Summary
- Replace `Action SignalSuspendedToInvoker` on `FlowState` with a `TaskCompletionSource`-backed `SuspendedTask` and `NotifySuspension()` method
- Remove `suspend` parameter from `FlowsManager.AddFlow` — Invoker now wires up suspension via `ContinueWith` on the returned `FlowState.SuspendedTask`
- Clean up test call sites that passed dummy `() => { }` lambdas

## Test plan
- [x] All 553 core tests pass