### PR TITLE
Use FlowState directly in QueueManager

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,8 @@
       "Bash(git -C /Users/stidsborg/Repos/Cleipnir.ResilientFunctions diff)",
       "Bash(git -C /Users/stidsborg/Repos/Cleipnir.ResilientFunctions log --oneline -5)",
       "Bash(git commit:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(git push:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,8 @@
       "Bash(git commit -m \"$\\(cat <<''EOF''\nRemoved unused QueueFlag and associated tests\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
       "Bash(git -C /Users/stidsborg/Repos/Cleipnir.ResilientFunctions diff)",
       "Bash(git -C /Users/stidsborg/Repos/Cleipnir.ResilientFunctions log --oneline -5)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -561,7 +561,7 @@ public abstract class MessagesSubscriptionTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -575,7 +575,6 @@ public abstract class MessagesSubscriptionTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message = await queueClient.Pull<GoodMessage>(
@@ -625,7 +624,7 @@ public abstract class MessagesSubscriptionTests
                 storedId = workflow.StoredId;
                 var minimumTimeout = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, minimumTimeout);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, minimumTimeout);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -639,7 +638,6 @@ public abstract class MessagesSubscriptionTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
 
                 var queueClient = await queueManager.CreateQueueClient();
 
@@ -687,7 +685,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -701,7 +699,6 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 // Pull envelope for specific receiver

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -570,8 +570,7 @@ public abstract class MessagesSubscriptionTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -633,8 +632,7 @@ public abstract class MessagesSubscriptionTests
                     unhandledExceptionHandler,
                     minimumTimeout,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,minimumTimeout);
@@ -694,8 +692,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -561,19 +561,21 @@ public abstract class MessagesSubscriptionTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     exceptionThrowingSerializer,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message = await queueClient.Pull<GoodMessage>(
@@ -623,19 +625,21 @@ public abstract class MessagesSubscriptionTests
                 storedId = workflow.StoredId;
                 var minimumTimeout = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, minimumTimeout);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     minimumTimeout,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,minimumTimeout);
+                flowsManager.AddFlow(flowState);
 
                 var queueClient = await queueManager.CreateQueueClient();
 
@@ -683,19 +687,21 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 // Pull envelope for specific receiver

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -36,19 +36,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
 
@@ -87,19 +89,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId(), TimeSpan.FromMilliseconds(100));
 
@@ -133,19 +137,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -184,19 +190,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -236,19 +244,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(
                     workflow,
@@ -289,19 +299,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
                 var message2 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -344,19 +356,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -397,19 +411,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default with { MessagesDefaultMaxWaitForCompletion = TimeSpan.FromMinutes(1) }
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 lock (queueClients)
                     queueClients[workflow.FlowId.Instance.Value] = queueClient;
@@ -462,19 +478,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 while (true)
@@ -529,19 +547,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)
@@ -558,19 +578,21 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
                     functionStore.MessageStore,
                     DefaultSerializer.Instance,
                     workflow.Effect,
+                    flowState,
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
+                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -36,7 +36,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -50,7 +50,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
 
@@ -89,7 +88,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -103,7 +102,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId(), TimeSpan.FromMilliseconds(100));
 
@@ -137,7 +135,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -151,7 +149,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -190,7 +187,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -204,7 +201,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<object>(
                     workflow,
@@ -244,7 +240,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -258,7 +254,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message = await queueClient.Pull<string>(
                     workflow,
@@ -299,7 +294,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -313,7 +308,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
                 var message2 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -356,7 +350,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -370,7 +364,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 var message1 = await queueClient.Pull<string>(workflow, workflow.Effect.CreateNextImplicitId());
@@ -411,7 +404,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -425,7 +418,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default with { MessagesDefaultMaxWaitForCompletion = TimeSpan.FromMinutes(1) }
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
                 lock (queueClients)
                     queueClients[workflow.FlowId.Instance.Value] = queueClient;
@@ -478,7 +470,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -492,7 +484,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 while (true)
@@ -547,7 +538,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -561,7 +552,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)
@@ -578,7 +568,7 @@ public abstract class MessagesTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager(functionStore, () => DateTime.UtcNow);
-                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -592,7 +582,6 @@ public abstract class MessagesTests
                     SettingsWithDefaults.Default
                 );
 
-                flowsManager.AddFlow(flowState);
                 var queueClient = await queueManager.CreateQueueClient();
 
                 for (var i = 0; i < 10; i++)

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -45,8 +45,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -97,8 +96,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -144,8 +142,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -196,8 +193,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -249,8 +245,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -303,8 +298,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -359,8 +353,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -413,8 +406,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default with { MessagesDefaultMaxWaitForCompletion = TimeSpan.FromMinutes(1) },
-                    flowsManager
+                    SettingsWithDefaults.Default with { MessagesDefaultMaxWaitForCompletion = TimeSpan.FromMinutes(1) }
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -479,8 +471,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -547,8 +538,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);
@@ -577,8 +567,7 @@ public abstract class MessagesTests
                     unhandledExceptionHandler,
                     flowTimeouts,
                     () => DateTime.UtcNow,
-                    SettingsWithDefaults.Default,
-                    flowsManager
+                    SettingsWithDefaults.Default
                 );
 
                 flowsManager.AddFlow(workflow.StoredId, queueManager,flowTimeouts);

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -1,7 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Helpers;
-using Cleipnir.ResilientFunctions.Queuing;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
@@ -12,7 +11,6 @@ public class FlowState
     private readonly TaskCompletionSource _suspendedTcs = new();
 
     public StoredId Id { get; }
-    public QueueManager QueueManager { get; }
     public int Subflows { get; private set; }
     public int WaitingSubflows { get; private set; }
     public FlowTimeouts Timeouts { get; }
@@ -22,13 +20,11 @@ public class FlowState
 
     public FlowState(
         StoredId id,
-        QueueManager queueManager,
         int subflows,
         int waitingSubflows,
         FlowTimeouts timeouts)
     {
         Id = id;
-        QueueManager = queueManager;
         Subflows = subflows;
         WaitingSubflows = waitingSubflows;
         Timeouts = timeouts;

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -13,8 +13,8 @@ public class FlowState
 
     public StoredId Id { get; }
     public QueueManager QueueManager { get; }
-    public int Threads { get; private set; }
-    public int WaitingThreads { get; private set; }
+    public int Subflows { get; private set; }
+    public int WaitingSubflows { get; private set; }
     public FlowTimeouts Timeouts { get; }
     public AsyncSignal InterruptSignal { get; } = new();
     public bool Suspended { get; private set; }
@@ -23,43 +23,43 @@ public class FlowState
     public FlowState(
         StoredId id,
         QueueManager queueManager,
-        int threads,
-        int waitingThreads,
+        int subflows,
+        int waitingSubflows,
         FlowTimeouts timeouts)
     {
         Id = id;
         QueueManager = queueManager;
-        Threads = threads;
-        WaitingThreads = waitingThreads;
+        Subflows = subflows;
+        WaitingSubflows = waitingSubflows;
         Timeouts = timeouts;
         SuspendedTask = _suspendedTcs.Task;
     }
 
-    public void NewThreadStarted()
+    public void SubflowStarted()
     {
         lock (_lock)
-            Threads++;
+            Subflows++;
     }
 
-    public void ThreadCompleted()
+    public void SubflowCompleted()
     {
         lock (_lock)
-            Threads--;
+            Subflows--;
     }
 
-    public void ThreadSuspended()
+    public void SubflowWaiting()
     {
         lock (_lock)
-            WaitingThreads++;
+            WaitingSubflows++;
     }
 
-    public bool ResumeThread()
+    public bool ResumeSubflow()
     {
         lock (_lock)
             if (Suspended)
                 return false;
             else
-                WaitingThreads--;
+                WaitingSubflows--;
 
         return true;
     }
@@ -67,12 +67,10 @@ public class FlowState
     public void Interrupt()
     {
         lock (_lock)
-        {
             if (Suspended)
                 return;
-            
-            WaitingThreads = 0;
-        }
+            else
+                WaitingSubflows = 0;
         
         InterruptSignal.Fire();
     }
@@ -80,7 +78,7 @@ public class FlowState
     public bool Suspend()
     {
         lock (_lock)
-            if (Threads == WaitingThreads)
+            if (Subflows == WaitingSubflows)
                 Suspended = true;
             else
                 return false;

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -43,13 +43,10 @@ public class FlowsManager : IDisposable
 
     public void Dispose() => _disposed = true;
 
-    public FlowState CreateFlowState(StoredId id, FlowTimeouts timeouts)
-        => new(id, subflows: 1, waitingSubflows: 0, timeouts);
-
-    public void AddFlow(FlowState flowState)
+    public FlowState CreateFlow(StoredId id, FlowTimeouts timeouts)
     {
         lock (_lock)
-            _dict[flowState.Id] = flowState;
+            return _dict[id] = new FlowState(id, subflows: 1, waitingSubflows: 0, timeouts);;
     }
 
     public void RemoveFlow(StoredId id, FlowState flowState)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -47,7 +47,11 @@ public class FlowsManager : IDisposable
     public FlowState AddFlow(StoredId id, QueueManager queueManager, FlowTimeouts timeouts)
     {
         lock (_lock)
-            return _dict[id] = new FlowState(id, queueManager, threads: 1, waitingThreads: 0, timeouts);
+        {
+            var flowState = new FlowState(id, queueManager, subflows: 1, waitingSubflows: 0, timeouts);
+            queueManager.AttachFlowState(flowState);
+            return _dict[id] = flowState;
+        }
     }
 
     public void RemoveFlow(StoredId id, FlowState flowState)
@@ -76,45 +80,14 @@ public class FlowsManager : IDisposable
     {
         lock (_lock)
             if (_dict.TryGetValue(id, out var flowState))
-                flowState.NewThreadStarted();
+                flowState.SubflowStarted();
     }
 
     public void CompleteThread(StoredId id)
     {
         lock (_lock)
             if (_dict.TryGetValue(id, out var flowState))
-                flowState.ThreadCompleted();
-    }
-
-    public bool ThreadResumed(StoredId id)
-    {
-        lock (_lock)
-            if (_dict.TryGetValue(id, out var flowState))
-                return flowState.ResumeThread();
-
-        return false;
-    }
-
-    public void SuspendThread(StoredId id)
-    {
-        lock (_lock)
-            if (_dict.TryGetValue(id, out var flowState))
-                flowState.ThreadSuspended();
-    }
-
-    public Task GetInterruptedSignal(StoredId id)
-    {
-        lock (_lock)
-            return _dict.TryGetValue(id, out var flowState)
-                ? flowState.InterruptSignal.Wait()
-                : Task.CompletedTask;
-    }
-
-    public void SignalInterrupt(StoredId id)
-    {
-        lock (_lock)
-            if (_dict.TryGetValue(id, out var flowState))
-                flowState.InterruptSignal.Fire();
+                flowState.SubflowCompleted();
     }
 
     [DoesNotReturn]

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain.Exceptions.Commands;
-using Cleipnir.ResilientFunctions.Queuing;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
@@ -44,14 +43,13 @@ public class FlowsManager : IDisposable
 
     public void Dispose() => _disposed = true;
 
-    public FlowState AddFlow(StoredId id, QueueManager queueManager, FlowTimeouts timeouts)
+    public FlowState CreateFlowState(StoredId id, FlowTimeouts timeouts)
+        => new(id, subflows: 1, waitingSubflows: 0, timeouts);
+
+    public void AddFlow(FlowState flowState)
     {
         lock (_lock)
-        {
-            var flowState = new FlowState(id, queueManager, subflows: 1, waitingSubflows: 0, timeouts);
-            queueManager.AttachFlowState(flowState);
-            return _dict[id] = flowState;
-        }
+            _dict[flowState.Id] = flowState;
     }
 
     public void RemoveFlow(StoredId id, FlowState flowState)
@@ -64,16 +62,11 @@ public class FlowsManager : IDisposable
     public async Task Interrupt(IReadOnlyList<StoredId> ids)
     {
         await _functionStore.ResetInterrupted(ids);
-        
+
         lock (_lock)
             foreach (var id in ids)
-            {
-                if (!_dict.TryGetValue(id, out var flowState))
-                    continue;
-                
-                flowState.Interrupt();
-                Task.Run(() => flowState.QueueManager.FetchMessagesOnce());
-            }
+                if (_dict.TryGetValue(id, out var flowState))
+                    flowState.Interrupt();
     }
 
     public void StartThread(StoredId id)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -433,8 +433,8 @@ internal class InvocationHelper<TParam, TReturn>
     public DistributedSemaphores CreateSemaphores(StoredId storedId, Effect effect, FlowsManager flowsManager)
         => new(effect, _functionStore.SemaphoreStore, storedId, Interrupt, flowsManager);
 
-    public QueueManager CreateQueueManager(FlowId flowId, StoredId storedId, Effect effect, FlowTimeouts timeouts, UnhandledExceptionHandler unhandledExceptionHandler)
-        => new(flowId, storedId, _functionStore.MessageStore, Serializer, effect, unhandledExceptionHandler, timeouts, UtcNow, _settings);
+    public QueueManager CreateQueueManager(FlowId flowId, StoredId storedId, Effect effect, FlowState flowState, FlowTimeouts timeouts, UnhandledExceptionHandler unhandledExceptionHandler)
+        => new(flowId, storedId, _functionStore.MessageStore, Serializer, effect, flowState, unhandledExceptionHandler, timeouts, UtcNow, _settings);
 
     public StoredId MapToStoredId(FlowId flowId) => StoredId.Create(_storedType, flowId.Instance.Value);
     

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -433,8 +433,8 @@ internal class InvocationHelper<TParam, TReturn>
     public DistributedSemaphores CreateSemaphores(StoredId storedId, Effect effect, FlowsManager flowsManager)
         => new(effect, _functionStore.SemaphoreStore, storedId, Interrupt, flowsManager);
 
-    public QueueManager CreateQueueManager(FlowId flowId, StoredId storedId, Effect effect, FlowTimeouts timeouts, UnhandledExceptionHandler unhandledExceptionHandler, FlowsManager flowsManager)
-        => new(flowId, storedId, _functionStore.MessageStore, Serializer, effect, unhandledExceptionHandler, timeouts, UtcNow, _settings, flowsManager);
+    public QueueManager CreateQueueManager(FlowId flowId, StoredId storedId, Effect effect, FlowTimeouts timeouts, UnhandledExceptionHandler unhandledExceptionHandler)
+        => new(flowId, storedId, _functionStore.MessageStore, Serializer, effect, unhandledExceptionHandler, timeouts, UtcNow, _settings);
 
     public StoredId MapToStoredId(FlowId flowId) => StoredId.Create(_storedType, flowId.Instance.Value);
     

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -289,7 +289,7 @@ public class Invoker<TParam, TReturn>
 
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
-            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler, _flowsManager);
+            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
             var workflow = new Workflow(flowId, storedId, effect, _utilities, correlations, semaphores, queueManager, _invocationHelper.UtcNow, messageWriter, _flowsManager);
@@ -340,7 +340,7 @@ public class Invoker<TParam, TReturn>
 
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
-            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler, _flowsManager);
+            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
 

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -54,7 +54,7 @@ public class Invoker<TParam, TReturn>
             if (parentWorkflow.Effect.Contains(scheduledAlreadyParentId!))
                 return _invocationHelper.CreateInnerScheduled([flowId], parentWorkflow, detach);
 
-        var (created, workflow, disposables, queueManager, timeouts, storageSession) = await PrepareForInvocation(flowId, storedId, param, parentWorkflow?.StoredId, initialState);
+        var (created, workflow, disposables, queueManager, flowState, timeouts, storageSession) = await PrepareForInvocation(flowId, storedId, param, parentWorkflow?.StoredId, initialState);
         await (parentWorkflow?.Effect.Upsert(scheduledAlreadyParentId!, true, alias: null, flush: false) ?? Task.CompletedTask);
 
         CurrentFlow._workflow.Value = workflow;
@@ -62,11 +62,7 @@ public class Invoker<TParam, TReturn>
             return _invocationHelper.CreateInnerScheduled([flowId], parentWorkflow, detach);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        var flowState = _flowsManager.AddFlow(
-            storedId,
-            queueManager,
-            timeouts
-        );
+        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -158,15 +154,11 @@ public class Invoker<TParam, TReturn>
 
     public async Task<InnerScheduled<TReturn>> ScheduleRestart(StoredId storedId)
     {
-        var (inner, param, humanInstanceId, workflow, disposables, queueManager, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId);
+        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId);
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        var flowState = _flowsManager.AddFlow(
-            storedId,
-            queueManager,
-            timeouts
-        );
+        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -217,15 +209,11 @@ public class Invoker<TParam, TReturn>
 
     internal async Task ScheduleRestart(StoredId storedId, RestartedFunction rf, Action onCompletion)
     {
-        var (inner, param, humanInstanceId, workflow, disposables, queueManager, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId, rf);
+        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId, rf);
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        var flowState = _flowsManager.AddFlow(
-            storedId,
-            queueManager,
-            timeouts
-        );
+        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -289,7 +277,9 @@ public class Invoker<TParam, TReturn>
 
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
-            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler);
+
+            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts);
+            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
             var workflow = new Workflow(flowId, storedId, effect, _utilities, correlations, semaphores, queueManager, _invocationHelper.UtcNow, messageWriter, _flowsManager);
@@ -299,6 +289,7 @@ public class Invoker<TParam, TReturn>
                 workflow,
                 Disposable.Combine(disposables),
                 queueManager,
+                flowState,
                 flowTimeouts
             );
         }
@@ -312,7 +303,7 @@ public class Invoker<TParam, TReturn>
             if (!success) Disposable.Combine(disposables).Dispose();
         }
     }
-    private record PreparedInvocation(bool Persisted, Workflow Workflow, IDisposable Disposables, QueueManager QueueManager, FlowTimeouts FlowTimeouts, IStorageSession? StorageSession = null);
+    private record PreparedInvocation(bool Persisted, Workflow Workflow, IDisposable Disposables, QueueManager QueueManager, FlowState FlowState, FlowTimeouts FlowTimeouts, IStorageSession? StorageSession = null);
 
     private async Task<PreparedReInvocation> PrepareForReInvocation(StoredId storedId)
     {
@@ -340,7 +331,8 @@ public class Invoker<TParam, TReturn>
 
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
-            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowTimeouts, _unhandledExceptionHandler);
+            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts);
+            var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
 
@@ -364,6 +356,7 @@ public class Invoker<TParam, TReturn>
                 workflow,
                 Disposable.Combine(disposables),
                 queueManager,
+                flowState,
                 flowTimeouts,
                 parent,
                 storageSession
@@ -383,6 +376,7 @@ public class Invoker<TParam, TReturn>
         Workflow Workflow,
         IDisposable Disposables,
         QueueManager QueueManager,
+        FlowState FlowState,
         FlowTimeouts FlowTimeouts,
         StoredId? Parent,
         IStorageSession? StorageSession

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -57,12 +57,12 @@ public class Invoker<TParam, TReturn>
         var (created, workflow, disposables, queueManager, flowState, timeouts, storageSession) = await PrepareForInvocation(flowId, storedId, param, parentWorkflow?.StoredId, initialState);
         await (parentWorkflow?.Effect.Upsert(scheduledAlreadyParentId!, true, alias: null, flush: false) ?? Task.CompletedTask);
 
-        CurrentFlow._workflow.Value = workflow;
         if (!created)
             return _invocationHelper.CreateInnerScheduled([flowId], parentWorkflow, detach);
 
+        CurrentFlow._workflow.Value = workflow;
+
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -158,7 +158,6 @@ public class Invoker<TParam, TReturn>
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -213,7 +212,6 @@ public class Invoker<TParam, TReturn>
         var flowId = new FlowId(_flowType, humanInstanceId);
 
         var tcs = new TaskCompletionSource<TReturn>();
-        _flowsManager.AddFlow(flowState);
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -264,6 +262,16 @@ public class Invoker<TParam, TReturn>
             disposables.Add(isWorkflowRunningDisposable);
             success = persisted;
 
+            if (!persisted)
+                return new PreparedInvocation(
+                    Persisted: false,
+                    Workflow: null!,
+                    Disposable.Combine(disposables),
+                    QueueManager: null!,
+                    FlowState: null!,
+                    FlowTimeouts: null!
+                );
+
             var flowTimeouts = new FlowTimeouts();
 
             var effect = _invocationHelper.CreateEffect(
@@ -278,7 +286,7 @@ public class Invoker<TParam, TReturn>
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
 
-            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts);
+            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
             var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
@@ -331,7 +339,7 @@ public class Invoker<TParam, TReturn>
 
             var correlations = _invocationHelper.CreateCorrelations(flowId);
             var semaphores = _invocationHelper.CreateSemaphores(storedId, effect, _flowsManager);
-            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts);
+            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
             var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
 using Cleipnir.ResilientFunctions.Domain;
+using Cleipnir.ResilientFunctions.Domain.Exceptions.Commands;
 using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Storage;
 
@@ -23,12 +24,14 @@ public class QueueManager(
     FlowTimeouts timeouts,
     UtcNow utcNow,
     SettingsWithDefaults settings,
-    FlowsManager flowsManager,
     int maxIdempotencyKeyCount = 100,
     TimeSpan? maxIdempotencyKeyTtl = null)
     : IDisposable
 {
     private readonly Lock _lock = new();
+    private FlowState _flowState = null!;
+
+    public void AttachFlowState(FlowState flowState) => _flowState = flowState;
 
     private readonly EffectId _toRemoveNextId = new([-1, 0]);
     private readonly EffectId _idempotencyKeysId = new([-1, -1]);
@@ -151,14 +154,14 @@ public class QueueManager(
         }
         finally
         {
-            flowsManager.SignalInterrupt(storedId);
+            _flowState.InterruptSignal.Fire();
             _semaphoreSlim.Release();
         }
     }
 
     private (MessageData? Matched, int PositionToRemoveIndex, Task PulseTask) TryTakeMessage(MessagePredicate predicate)
     {
-        var interruptedSignal = flowsManager.GetInterruptedSignal(storedId);
+        var interruptedSignal = _flowState.InterruptSignal.Wait();
         
         lock (_lock)
         {
@@ -272,20 +275,17 @@ public class QueueManager(
                 return matched.Envelope;
             }
             
-            flowsManager.SuspendThread(storedId);
+            _flowState.SubflowWaiting();
             await Task.WhenAny(interruptSignal, timeoutTask, maxWaitTask);
-            var success = flowsManager.ThreadResumed(storedId);
+            var success = _flowState.ResumeSubflow();
             if (!success)
                 await new TaskCompletionSource().Task;
-            
+
             if (timeoutTask.IsCompleted)
                 return null;
 
             if (maxWaitTask.IsCompleted)
-            {
-                await flowsManager.Suspend(storedId);
-                return null;
-            }
+                throw new SuspendInvocationException();
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -7,6 +7,7 @@ using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Domain.Exceptions.Commands;
+using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Storage;
 
@@ -20,6 +21,7 @@ public class QueueManager(
     IMessageStore messageStore,
     ISerializer serializer,
     Effect effect,
+    FlowState flowState,
     UnhandledExceptionHandler unhandledExceptionHandler,
     FlowTimeouts timeouts,
     UtcNow utcNow,
@@ -29,9 +31,6 @@ public class QueueManager(
     : IDisposable
 {
     private readonly Lock _lock = new();
-    private FlowState _flowState = null!;
-
-    public void AttachFlowState(FlowState flowState) => _flowState = flowState;
 
     private readonly EffectId _toRemoveNextId = new([-1, 0]);
     private readonly EffectId _idempotencyKeysId = new([-1, -1]);
@@ -40,6 +39,7 @@ public class QueueManager(
 
     private IdempotencyKeys? _idempotencyKeys;
     private int _nextToRemoveIndex = 0;
+    private readonly AsyncSignal _interruptSignal = new();
     private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1);
     private bool _initialized = false;
     private volatile bool _disposed;
@@ -84,6 +84,16 @@ public class QueueManager(
         {
             _semaphoreSlim.Release();
         }
+
+        _ = Task.Run(async () =>
+        {
+            while (!_disposed)
+            {
+                await flowState.InterruptSignal.Wait();
+                if (!_disposed)
+                    await FetchMessagesOnce();
+            }
+        });
         
         await FetchMessagesOnce();
         _ = Task.Run(FetchMessages);
@@ -154,14 +164,14 @@ public class QueueManager(
         }
         finally
         {
-            _flowState.InterruptSignal.Fire();
+            _interruptSignal.Fire();
             _semaphoreSlim.Release();
         }
     }
 
     private (MessageData? Matched, int PositionToRemoveIndex, Task PulseTask) TryTakeMessage(MessagePredicate predicate)
     {
-        var interruptedSignal = _flowState.InterruptSignal.Wait();
+        var interruptedSignal = _interruptSignal.Wait();
         
         lock (_lock)
         {
@@ -274,10 +284,10 @@ public class QueueManager(
                 timeouts.RemoveTimeout(timeoutId);
                 return matched.Envelope;
             }
-            
-            _flowState.SubflowWaiting();
+
+            flowState.SubflowWaiting();
             await Task.WhenAny(interruptSignal, timeoutTask, maxWaitTask);
-            var success = _flowState.ResumeSubflow();
+            var success = flowState.ResumeSubflow();
             if (!success)
                 await new TaskCompletionSource().Task;
 


### PR DESCRIPTION
## Summary
- QueueManager now stores a direct `FlowState` reference (attached by `FlowsManager.AddFlow`) instead of calling `FlowsManager` methods keyed by `StoredId`.
- Removes the now-unused per-id dispatch methods from `FlowsManager` (`SignalInterrupt`, `GetInterruptedSignal`, `SuspendThread`, `ThreadResumed`). `Suspend` stays (still used by `DistributedSemaphore`).
- Includes an in-flight `Threads` → `Subflows` rename on `FlowState`.

## Test plan
- [ ] `dotnet test ./Core/Cleipnir.ResilientFunctions.Tests` (messaging + full suite)
- [ ] DB-backed suites (Postgres / SqlServer / MariaDB)