### PR TITLE
Update MailKit to 4.16.0

### DIFF
--- a/Samples/Sample.ConsoleApp/Sample.ConsoleApp.csproj
+++ b/Samples/Sample.ConsoleApp/Sample.ConsoleApp.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MailKit" Version="4.15.1" />
+      <PackageReference Include="MailKit" Version="4.16.0" />
       <PackageReference Include="Serilog" Version="4.3.1" />
     </ItemGroup>
     


### PR DESCRIPTION
## Summary
- Bump MailKit NuGet package in `Sample.ConsoleApp` from 4.15.1 to 4.16.0

## Test plan
- [x] `dotnet build Samples/Sample.ConsoleApp/Sample.ConsoleApp.csproj` succeeds