### PR TITLE
Update Microsoft.Data.SqlClient to 7.0.1

### DIFF
--- a/Stores/EnsureDatabaseConnections/EnsureDatabaseConnections.csproj
+++ b/Stores/EnsureDatabaseConnections/EnsureDatabaseConnections.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="MySqlConnector" Version="2.5.0" />
         <PackageReference Include="Npgsql" Version="10.0.2" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     </ItemGroup>
     
 </Project>

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/Cleipnir.ResilientFunctions.SqlServer.csproj
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/Cleipnir.ResilientFunctions.SqlServer.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Bump Microsoft.Data.SqlClient from 6.1.4 to 7.0.1 in `Cleipnir.ResilientFunctions.SqlServer` and `EnsureDatabaseConnections`

## Test plan
- [x] `dotnet build` passes for SqlServer project and EnsureDatabaseConnections
- [x] All 119 SqlServer store tests pass against live SQL Server