### PR TITLE
Update Microsoft.NET.Test.Sdk to 18.5.0 and MSTest to 4.2.1

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Cleipnir.ResilientFunctions.Tests.csproj
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Cleipnir.ResilientFunctions.Tests.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="coverlet.collector" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Cleipnir.ResilientFunctions.MariaDB.Tests.csproj
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Cleipnir.ResilientFunctions.MariaDB.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="coverlet.collector" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Cleipnir.ResilientFunctions.PostgreSQL.Tests.csproj
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Cleipnir.ResilientFunctions.PostgreSQL.Tests.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="coverlet.collector" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Cleipnir.ResilientFunctions.SqlServer.Tests.csproj
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Cleipnir.ResilientFunctions.SqlServer.Tests.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="coverlet.collector" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.0
- Bump MSTest.TestAdapter and MSTest.TestFramework from 4.1.0 to 4.2.1
- Applied across Core, PostgreSQL, MariaDB and SqlServer test projects

## Test plan
- [x] All four test projects build clean
- [x] All 230 in-memory `RFunctionTests` pass after a clean rebuild