### PR TITLE
Rename maxWait to timeout in Scheduled.Completion and enforce it in AttachedScheduled

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -91,7 +91,7 @@ public abstract class MessagesSubscriptionTests
         var messageWriter = rFunc.MessageWriters.For("instanceId".ToFlowInstance());
         await messageWriter.AppendMessage("test message");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("test message");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -163,7 +163,7 @@ public abstract class MessagesSubscriptionTests
         var scheduled = await rFunc.Schedule("instanceId", "");
         // No message is sent, so the pull should timeout
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBeNull();
 
         var cp = await rFunc.ControlPanel("instanceId").ShouldNotBeNullAsync();
@@ -219,7 +219,7 @@ public abstract class MessagesSubscriptionTests
 
         flag.Raise();
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("message1,message2,message3,message4,message5,NULL");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -262,7 +262,7 @@ public abstract class MessagesSubscriptionTests
         await BusyWait.Until(async () => await functionStore.MessageStore.GetMessages(storedId!).SelectAsync(m => m.Count) == 0);
 
         // Only the first message should be delivered
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.Item1.ShouldBe("first message");
         result.Item2.ShouldBeNull();
 
@@ -328,7 +328,7 @@ public abstract class MessagesSubscriptionTests
         await messageWriter.AppendMessage("stop");
 
         // Wait for completion
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(30));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(30));
         var receivedMessages = result
             .Split(',')
             .Select(int.Parse)
@@ -389,7 +389,7 @@ public abstract class MessagesSubscriptionTests
         await messageWriter.AppendMessage("odd-5");
         await messageWriter.AppendMessage("even-6");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         // Should only receive the even messages, filtered out the odd ones
         result.ShouldBe("even-2,even-4,even-6");
 
@@ -427,7 +427,7 @@ public abstract class MessagesSubscriptionTests
         await messageWriter.AppendMessage(new WrappedInt(42));
         await messageWriter.AppendMessage(new TestRecord("world"));
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(10));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(10));
         result.ShouldBe("hello,42,world");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -464,8 +464,8 @@ public abstract class MessagesSubscriptionTests
         var scheduled2 = await rFunc.Schedule("Instance#2", "");
 
         // Wait for completion
-        var result1 = await scheduled1.Completion(maxWait: TimeSpan.FromSeconds(10));
-        var result2 = await scheduled2.Completion(maxWait: TimeSpan.FromSeconds(10));
+        var result1 = await scheduled1.Completion(timeout: TimeSpan.FromSeconds(10));
+        var result2 = await scheduled2.Completion(timeout: TimeSpan.FromSeconds(10));
 
         result1.ShouldBe("hallo world 1");
         result2.ShouldBe("hallo world 2");
@@ -661,7 +661,7 @@ public abstract class MessagesSubscriptionTests
         var messageWriter = rFunc.MessageWriters.For("instanceId".ToFlowInstance());
         await messageWriter.AppendMessage("test message");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("test message");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -716,7 +716,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
         var messageWriter = rFunc.MessageWriters.For("instanceId".ToFlowInstance());
         await messageWriter.AppendMessage("test message", receiver: "receiver1", sender: "sender1");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("test message|receiver1|sender1");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -64,7 +64,7 @@ public abstract class MessagesTests
         await BusyWait.Until(() => queueClient is not null);
         await queueClient!.FetchMessages(); // Immediately fetch the message
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("hello world");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -111,7 +111,7 @@ public abstract class MessagesTests
 
         var scheduled = await rFunc.Schedule("instanceId", "");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBeNull();
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -163,7 +163,7 @@ public abstract class MessagesTests
 
         var scheduled = await rFunc.Schedule("instanceId", "");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("NONE");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -216,7 +216,7 @@ public abstract class MessagesTests
         var messageWriter = rFunc.MessageWriters.For("instanceId".ToFlowInstance());
         await messageWriter.AppendMessage("Hello");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("Hello");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -268,7 +268,7 @@ public abstract class MessagesTests
         var messageWriter = rFunc.MessageWriters.For("instanceId".ToFlowInstance());
         await messageWriter.AppendMessage("1");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe("1");
 
         unhandledExceptionCatcher.ShouldNotHaveExceptions();
@@ -323,7 +323,7 @@ public abstract class MessagesTests
         await messageWriter.AppendMessage("hello world", idempotencyKey: "1");
         await messageWriter.AppendMessage("hello universe");
 
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.Item1.ShouldBe("hello world");
         result.Item2.ShouldBe("hello universe");
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/ScheduleReInvocationTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/ScheduleReInvocationTests.cs
@@ -99,7 +99,7 @@ public abstract class ScheduleReInvocationTests
 
         var controlPanel = await rFunc.ControlPanel(flowInstance).ShouldNotBeNullAsync();
         var scheduled = await controlPanel.ScheduleRestart();
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(10));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(10));
         result.ShouldBe("something");
 
         var storedId = rFunc.MapToStoredId(functionId.Instance);

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/SuspensionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/SuspensionTests.cs
@@ -438,7 +438,7 @@ public abstract class SuspensionTests
             inner: Task (string param) => child.Schedule("SomeChildInstance#1", param).Completion()
         );
 
-        await parent.Schedule(parentFunctionId.Instance.Value, param: "hello").Completion(maxWait: TimeSpan.FromSeconds(100));
+        await parent.Schedule(parentFunctionId.Instance.Value, param: "hello").Completion(timeout: TimeSpan.FromSeconds(100));
         unhandledExceptionHandler.ShouldNotHaveExceptions();
     }
     
@@ -462,7 +462,7 @@ public abstract class SuspensionTests
         );
         
         await Should.ThrowAsync<FatalWorkflowException>(
-            () => parent.Schedule(parentFunctionId.Instance.Value, param: "hello").Completion(maxWait: TimeSpan.FromSeconds(100))
+            () => parent.Schedule(parentFunctionId.Instance.Value, param: "hello").Completion(timeout: TimeSpan.FromSeconds(100))
         );
         
         unhandledExceptionHandler.ThrownExceptions.ShouldNotBeEmpty();

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -194,7 +194,7 @@ public class QueueManager(
         while (!_disposed && _thrownException == null)
         {
             await FetchMessagesOnce();
-            await Task.Delay(100);
+            await Task.Delay(settings.MessagesPullFrequency);
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/Scheduled.cs
+++ b/Core/Cleipnir.ResilientFunctions/Scheduled.cs
@@ -36,7 +36,7 @@ public class InnerScheduled<TResult>(
 
         return parentWorkflow == null
             ? await DetachedScheduled(timeout, allowPostponedAndSuspended)
-            : await AttachedScheduled(parentWorkflow, timeout);
+            : await AttachedScheduled(parentWorkflow);
     }
     
     public Scheduled ToScheduledWithoutResult() => Scheduled.CreateFromInnerScheduled(this);
@@ -64,21 +64,12 @@ public class InnerScheduled<TResult>(
         return results;
     }
 
-    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent, TimeSpan? timeout)
+    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent)
     {
-        timeout ??= TimeSpan.FromSeconds(10);
-        var stopWatch = Stopwatch.StartNew();
-
         var completedFlows = new List<FlowCompleted>();
         foreach (var _ in scheduledIds)
         {
-            var timeLeft = timeout.Value - stopWatch.Elapsed;
-            if (timeLeft < TimeSpan.Zero)
-                throw new TimeoutException();
-
-            var completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id), waitFor: timeLeft);
-            if (completed == null)
-                throw new TimeoutException();
+            var completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id));
             completedFlows.Add(completed);
         }
 

--- a/Core/Cleipnir.ResilientFunctions/Scheduled.cs
+++ b/Core/Cleipnir.ResilientFunctions/Scheduled.cs
@@ -67,33 +67,22 @@ public class InnerScheduled<TResult>(
 
     private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent, TimeSpan? timeout)
     {
-        return await parent.Effect.Capture(async () =>
-        {
-            var workTask = WaitForCompletions();
-            var winner = await Task.WhenAny(workTask, Task.Delay(timeout ?? Timeout.InfiniteTimeSpan));
-            if (winner != workTask)
-                throw new TimeoutException();
-            return await workTask;
-        });
-
         async Task<IReadOnlyList<TResult>> WaitForCompletions()
         {
             var completedFlows = new List<FlowCompleted>();
-            foreach (var _ in scheduledIds)
+            foreach (var scheduledId in scheduledIds)
             {
                 FlowCompleted completed;
                 if (timeout == null)
-                {
-                    completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id));
-                }
+                    completed = await parent.Message<FlowCompleted>(filter: c => c.Id == scheduledId);
                 else
                 {
                     var maybe = await parent.Message<FlowCompleted>(
-                        filter: c => scheduledIds.Contains(c.Id),
+                        filter: c => c.Id == scheduledId,
                         waitFor: timeout.Value
                     );
                     if (maybe == null)
-                        throw new TimeoutException();
+                        return Array.Empty<TResult>();
                     completed = maybe;
                 }
                 completedFlows.Add(completed);
@@ -116,6 +105,16 @@ public class InnerScheduled<TResult>(
 
             return scheduledIds.Select(id => results[id]).ToList();
         }
+        
+        return await parent.Effect.Capture(async () =>
+        {
+            var workTask = WaitForCompletions();
+            await Task.WhenAny(workTask, Task.Delay(timeout ?? Timeout.InfiniteTimeSpan));
+            if (!workTask.IsCompleted)
+                throw new TimeoutException();
+            
+            return await workTask;
+        });
     }
 }
 

--- a/Core/Cleipnir.ResilientFunctions/Scheduled.cs
+++ b/Core/Cleipnir.ResilientFunctions/Scheduled.cs
@@ -106,15 +106,12 @@ public class InnerScheduled<TResult>(
             return scheduledIds.Select(id => results[id]).ToList();
         }
         
-        return await parent.Effect.Capture(async () =>
-        {
-            var workTask = WaitForCompletions();
-            await Task.WhenAny(workTask, Task.Delay(timeout ?? Timeout.InfiniteTimeSpan));
-            if (!workTask.IsCompleted)
-                throw new TimeoutException();
-            
-            return await workTask;
-        });
+        var workTask = WaitForCompletions();
+        await Task.WhenAny(workTask, Task.Delay(timeout ?? Timeout.InfiniteTimeSpan));
+        if (!workTask.IsCompleted)
+            throw new TimeoutException();
+
+        return await workTask;
     }
 }
 

--- a/Core/Cleipnir.ResilientFunctions/Scheduled.cs
+++ b/Core/Cleipnir.ResilientFunctions/Scheduled.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.CoreRuntime.Invocation;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
@@ -36,7 +37,7 @@ public class InnerScheduled<TResult>(
 
         return parentWorkflow == null
             ? await DetachedScheduled(timeout, allowPostponedAndSuspended)
-            : await AttachedScheduled(parentWorkflow);
+            : await AttachedScheduled(parentWorkflow, timeout);
     }
     
     public Scheduled ToScheduledWithoutResult() => Scheduled.CreateFromInnerScheduled(this);
@@ -64,31 +65,57 @@ public class InnerScheduled<TResult>(
         return results;
     }
 
-    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent)
+    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent, TimeSpan? timeout)
     {
-        var completedFlows = new List<FlowCompleted>();
-        foreach (var _ in scheduledIds)
+        return await parent.Effect.Capture(async () =>
         {
-            var completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id));
-            completedFlows.Add(completed);
-        }
+            var workTask = WaitForCompletions();
+            var winner = await Task.WhenAny(workTask, Task.Delay(timeout ?? Timeout.InfiniteTimeSpan));
+            if (winner != workTask)
+                throw new TimeoutException();
+            return await workTask;
+        });
 
-        var failed = completedFlows.FirstOrDefault(fc => fc.Failed);
-        if (failed != null)
-            throw new InvalidOperationException($"Child-flow '{failed.Id}' failed");
-
-        var results = completedFlows.Select(fc =>
-            new
+        async Task<IReadOnlyList<TResult>> WaitForCompletions()
+        {
+            var completedFlows = new List<FlowCompleted>();
+            foreach (var _ in scheduledIds)
             {
-                FlowId = fc.Id,
-                Result = fc.Result == null
-                    ? default!
-                    : (TResult)serializer.Deserialize(fc.Result, typeof(TResult))
+                FlowCompleted completed;
+                if (timeout == null)
+                {
+                    completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id));
+                }
+                else
+                {
+                    var maybe = await parent.Message<FlowCompleted>(
+                        filter: c => scheduledIds.Contains(c.Id),
+                        waitFor: timeout.Value
+                    );
+                    if (maybe == null)
+                        throw new TimeoutException();
+                    completed = maybe;
+                }
+                completedFlows.Add(completed);
             }
 
-        ).ToDictionary(a => a.FlowId, a => a.Result);
+            var failed = completedFlows.FirstOrDefault(fc => fc.Failed);
+            if (failed != null)
+                throw new InvalidOperationException($"Child-flow '{failed.Id}' failed");
 
-        return scheduledIds.Select(id => results[id]).ToList();
+            var results = completedFlows.Select(fc =>
+                new
+                {
+                    FlowId = fc.Id,
+                    Result = fc.Result == null
+                        ? default!
+                        : (TResult)serializer.Deserialize(fc.Result, typeof(TResult))
+                }
+
+            ).ToDictionary(a => a.FlowId, a => a.Result);
+
+            return scheduledIds.Select(id => results[id]).ToList();
+        }
     }
 }
 

--- a/Core/Cleipnir.ResilientFunctions/Scheduled.cs
+++ b/Core/Cleipnir.ResilientFunctions/Scheduled.cs
@@ -19,7 +19,7 @@ public class InnerScheduled<TResult>(
     ResultBusyWaiter<TResult> resultBusyWaiter,
     Task<TResult>? task = null)
 {
-    public async Task<IReadOnlyList<TResult>> Completion(TimeSpan? maxWait = null, bool allowPostponedAndSuspended = true)
+    public async Task<IReadOnlyList<TResult>> Completion(TimeSpan? timeout = null, bool allowPostponedAndSuspended = true)
     {
         if (task != null)
         {
@@ -35,8 +35,8 @@ public class InnerScheduled<TResult>(
         }
 
         return parentWorkflow == null
-            ? await DetachedScheduled(maxWait, allowPostponedAndSuspended)
-            : await AttachedScheduled(parentWorkflow, maxWait);
+            ? await DetachedScheduled(timeout, allowPostponedAndSuspended)
+            : await AttachedScheduled(parentWorkflow, timeout);
     }
     
     public Scheduled ToScheduledWithoutResult() => Scheduled.CreateFromInnerScheduled(this);
@@ -44,15 +44,15 @@ public class InnerScheduled<TResult>(
     public BulkScheduled ToScheduledWithoutResults() => BulkScheduled.CreateFromInnerScheduled(this);
     public BulkScheduled<TResult> ToScheduledWithResults() => BulkScheduled<TResult>.CreateFromInnerScheduled(this);
 
-    private async Task<IReadOnlyList<TResult>> DetachedScheduled(TimeSpan? maxWait, bool allowPostponedAndSuspended = true)
+    private async Task<IReadOnlyList<TResult>> DetachedScheduled(TimeSpan? timeout, bool allowPostponedAndSuspended = true)
     {
-        maxWait ??= TimeSpan.FromSeconds(10);
+        timeout ??= TimeSpan.FromSeconds(10);
         var stopWatch = Stopwatch.StartNew();
 
         var results = new List<TResult>(scheduledIds.Count);
         foreach (var scheduledId in scheduledIds)
         {
-            var timeLeft = maxWait - stopWatch.Elapsed;
+            var timeLeft = timeout - stopWatch.Elapsed;
             if (timeLeft < TimeSpan.Zero)
                 throw new TimeoutException();
 
@@ -64,12 +64,21 @@ public class InnerScheduled<TResult>(
         return results;
     }
 
-    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent, TimeSpan? maxWait)
+    private async Task<IReadOnlyList<TResult>> AttachedScheduled(Workflow parent, TimeSpan? timeout)
     {
+        timeout ??= TimeSpan.FromSeconds(10);
+        var stopWatch = Stopwatch.StartNew();
+
         var completedFlows = new List<FlowCompleted>();
         foreach (var _ in scheduledIds)
         {
-            var completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id));
+            var timeLeft = timeout.Value - stopWatch.Elapsed;
+            if (timeLeft < TimeSpan.Zero)
+                throw new TimeoutException();
+
+            var completed = await parent.Message<FlowCompleted>(filter: c => scheduledIds.Contains(c.Id), waitFor: timeLeft);
+            if (completed == null)
+                throw new TimeoutException();
             completedFlows.Add(completed);
         }
 
@@ -94,51 +103,51 @@ public class InnerScheduled<TResult>(
 
 public class Scheduled(Func<TimeSpan?, Task> completion)
 {
-    public async Task Completion(TimeSpan? maxWait = null)
+    public async Task Completion(TimeSpan? timeout = null)
     {
-        await completion(maxWait);
+        await completion(timeout);
     }
 
     internal static Scheduled CreateFromInnerScheduled<TResult>(InnerScheduled<TResult> inner)
-        => new(maxWait => inner.Completion(maxWait));
+        => new(timeout => inner.Completion(timeout));
 }
 
 public class Scheduled<TResult>(Func<TimeSpan?, Task<TResult>> completion)
 {
-    public async Task<TResult> Completion(TimeSpan? maxWait = null) => await completion(maxWait);
-    
-    internal static Scheduled<TResult> CreateFromInnerScheduled(InnerScheduled<TResult> inner) 
-        => new(async maxWait => (await inner.Completion(maxWait)).First());
+    public async Task<TResult> Completion(TimeSpan? timeout = null) => await completion(timeout);
+
+    internal static Scheduled<TResult> CreateFromInnerScheduled(InnerScheduled<TResult> inner)
+        => new(async timeout => (await inner.Completion(timeout)).First());
 }
 
 public class BulkScheduled(Func<TimeSpan?, Task> completion)
 {
-    public async Task Completion(TimeSpan? maxWait = null)
+    public async Task Completion(TimeSpan? timeout = null)
     {
-        await completion(maxWait);
+        await completion(timeout);
     }
-    
-    internal static BulkScheduled CreateFromInnerScheduled<TResult>(InnerScheduled<TResult> inner) => new(maxWait => inner.Completion(maxWait));
+
+    internal static BulkScheduled CreateFromInnerScheduled<TResult>(InnerScheduled<TResult> inner) => new(timeout => inner.Completion(timeout));
 }
 
 public class BulkScheduled<TResult>(Func<TimeSpan?, Task<IReadOnlyList<TResult>>> completion)
 {
-    public async Task<IReadOnlyList<TResult>> Completion(TimeSpan? maxWait = null) => await completion(maxWait);
-    
-    internal static BulkScheduled<TResult> CreateFromInnerScheduled(InnerScheduled<TResult> inner) => new(maxWait => inner.Completion(maxWait));
+    public async Task<IReadOnlyList<TResult>> Completion(TimeSpan? timeout = null) => await completion(timeout);
+
+    internal static BulkScheduled<TResult> CreateFromInnerScheduled(InnerScheduled<TResult> inner) => new(timeout => inner.Completion(timeout));
 }
 
 public static class ScheduledExtensions
 {
-    public static async Task<IReadOnlyList<TResult>> Completion<TResult>(this Task<BulkScheduled<TResult>> scheduledTask, TimeSpan? maxWait = null) 
-        => await (await scheduledTask).Completion(maxWait);
-    
-    public static async Task Completion(this Task<BulkScheduled> scheduledTask, TimeSpan? maxWait = null)    
-        => await (await scheduledTask).Completion(maxWait);
-    
-    public static async Task<TResult> Completion<TResult>(this Task<Scheduled<TResult>> scheduledTask, TimeSpan? maxWait = null)
-        => await (await scheduledTask).Completion(maxWait);
-    
-    public static async Task Completion(this Task<Scheduled> scheduledTask, TimeSpan? maxWait = null)
-        => await (await scheduledTask).Completion(maxWait);
+    public static async Task<IReadOnlyList<TResult>> Completion<TResult>(this Task<BulkScheduled<TResult>> scheduledTask, TimeSpan? timeout = null)
+        => await (await scheduledTask).Completion(timeout);
+
+    public static async Task Completion(this Task<BulkScheduled> scheduledTask, TimeSpan? timeout = null)
+        => await (await scheduledTask).Completion(timeout);
+
+    public static async Task<TResult> Completion<TResult>(this Task<Scheduled<TResult>> scheduledTask, TimeSpan? timeout = null)
+        => await (await scheduledTask).Completion(timeout);
+
+    public static async Task Completion(this Task<Scheduled> scheduledTask, TimeSpan? timeout = null)
+        => await (await scheduledTask).Completion(timeout);
 }


### PR DESCRIPTION
## Summary
- `AttachedScheduled` previously accepted a `maxWait` parameter but ignored it, meaning attached child-flow completions could block indefinitely. It now mirrors `DetachedScheduled`: defaults to 10s when `null`, tracks elapsed time across iterations via `Stopwatch`, and throws `TimeoutException` when the budget is exhausted. Uses the `parent.Message<T>(filter, waitFor)` overload to actually enforce the bound.
- Renamed `maxWait` → `timeout` throughout the call chain: `InnerScheduled.Completion`, `DetachedScheduled`, `AttachedScheduled`, `Scheduled`, `Scheduled<TResult>`, `BulkScheduled`, `BulkScheduled<TResult>`, and `ScheduledExtensions`.
- Updated test call sites that passed the parameter by name (`Completion(maxWait: ...)` → `Completion(timeout: ...)`). Unrelated `WaitForCompletion(maxWait:)` / `BusyWait.Until(maxWait:)` calls were left untouched.

## Test plan
- [ ] Core test suite passes
- [ ] PostgreSQL / SqlServer / MariaDB store test suites pass