### PR TITLE
Make IdempotencyKeys.Add return bool and persist eagerly

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/Queuing/IdempotencyKeys.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/IdempotencyKeys.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.Domain;
 
@@ -28,7 +27,7 @@ internal class IdempotencyKeys(EffectId parentId, Effect effect, int maxCount, T
         CleanUp();
     }
 
-    public EffectResult? Add(string idempotencyKey, long position)
+    public bool Add(string idempotencyKey, long position)
     {
         CleanUp();
 
@@ -40,14 +39,17 @@ internal class IdempotencyKeys(EffectId parentId, Effect effect, int maxCount, T
         int id;
         lock (_lock)
         {
+            if (_dictionary.Any(e => e.Value.IdempotencyKey == idempotencyKey && e.Value.Position == position))
+                return true;
             if (_dictionary.Any(e => e.Value.IdempotencyKey == idempotencyKey))
-                return null;
+                return false;
             
             id = _nextId++;
             _dictionary[id] = entry;
         }
 
-        return new EffectResult(parentId.CreateChild(id), entry.ToTuple(), Alias: null);
+        effect.FlushlessUpsert(parentId.CreateChild(id), entry.ToTuple(), alias: null);
+        return true;
     }
 
     private void Remove(int id)

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -128,11 +128,7 @@ public class QueueManager(
                 {
                     var msg = serializer.Deserialize(messageContent, serializer.ResolveType(messageType)!);
 
-                    var idempotencyKeyResult = idempotencyKey == null
-                        ? null
-                        : _idempotencyKeys!.Add(idempotencyKey, position);
-
-                    if (idempotencyKey != null && idempotencyKeyResult == null)
+                    if (idempotencyKey != null && !_idempotencyKeys!.Add(idempotencyKey, position))
                     {
                         await messageStore.DeleteMessages(storedId, [position]);
                         continue;
@@ -142,7 +138,6 @@ public class QueueManager(
                     var messageData = new MessageData(
                         envelope,
                         position,
-                        idempotencyKeyResult,
                         messageContent,
                         messageType,
                         receiver,
@@ -269,17 +264,13 @@ public class QueueManager(
             {
                 var toRemoveId = new EffectId([-1, 0, positionToRemoveIndex]);
                 effect.FlushlessUpserts(
-                    new List<EffectResult>(
-                    [
-                        new EffectResult(toRemoveId, matched.Position, Alias: null),
-                        new EffectResult(messageId, matched.MessageContentBytes, Alias: null),
-                        new EffectResult(messageTypeId, matched.MessageTypeBytes, Alias: null),
-                        new EffectResult(receiverId, matched.Receiver, Alias: null),
-                        new EffectResult(senderId, matched.Sender, Alias: null),
-                    ]).Concat(matched.IdempotencyKeyResult == null
-                        ? []
-                        : [matched.IdempotencyKeyResult])
-                );
+                [
+                    new EffectResult(toRemoveId, matched.Position, Alias: null),
+                    new EffectResult(messageId, matched.MessageContentBytes, Alias: null),
+                    new EffectResult(messageTypeId, matched.MessageTypeBytes, Alias: null),
+                    new EffectResult(receiverId, matched.Receiver, Alias: null),
+                    new EffectResult(senderId, matched.Sender, Alias: null),
+                ]);
 
                 timeouts.RemoveTimeout(timeoutId);
                 return matched.Envelope;
@@ -302,7 +293,6 @@ public class QueueManager(
     public record MessageData(
         Envelope Envelope,
         long Position,
-        EffectResult? IdempotencyKeyResult,
         byte[] MessageContentBytes,
         byte[] MessageTypeBytes,
         string? Receiver,


### PR DESCRIPTION
## Summary
- `IdempotencyKeys.Add` now returns `bool` instead of `EffectResult?` and calls `effect.FlushlessUpsert` itself when a new entry is inserted.
- Same `(key, position)` pair returns `true` (allows crash-recovery replay of the same message); same key at a different position returns `false` so the message is dropped.
- `QueueManager` no longer carries an `EffectResult? IdempotencyKeyResult` through `MessageData`, and `Subscribe` no longer concatenates it onto the per-message flush batch.

## Test plan
- [x] `dotnet build` (whole solution clean)
- [x] In-memory messaging tests: 56/56 passed
- [ ] CI: full test matrix (Postgres / SqlServer / MariaDB)