### PR TITLE
Effect: rename ClearNoFlush to FlushlessClear

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/Domain/Effect.cs
+++ b/Core/Cleipnir.ResilientFunctions/Domain/Effect.cs
@@ -240,7 +240,7 @@ public class Effect(EffectResults effectResults, UtcNow utcNow, FlowTimeouts flo
     }
 
     internal async Task Clear(EffectId id, bool flush) => await effectResults.Clear(id, flush);
-    internal void ClearNoFlush(EffectId id) => effectResults.ClearNoFlush(id);
+    internal void FlushlessClear(EffectId id) => effectResults.FlushlessClear(id);
     internal bool IsDirty(EffectId id) => effectResults.IsDirty(id);
     
     public async Task<TSeed> AggregateEach<T, TSeed>(

--- a/Core/Cleipnir.ResilientFunctions/Domain/EffectResults.cs
+++ b/Core/Cleipnir.ResilientFunctions/Domain/EffectResults.cs
@@ -413,7 +413,7 @@ public class EffectResults
             await Flush();
     }
     
-    public void ClearNoFlush(EffectId effectId)
+    public void FlushlessClear(EffectId effectId)
     {
         lock (_sync)
             if (_effectResults.ContainsKey(effectId))

--- a/Core/Cleipnir.ResilientFunctions/Queuing/IdempotencyKeys.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/IdempotencyKeys.cs
@@ -57,7 +57,7 @@ internal class IdempotencyKeys(EffectId rootId, Effect effect, int maxCount, Tim
         lock (_lock)
             _dictionary.Remove(id);
         
-        effect.ClearNoFlush(rootId.CreateChild(id));
+        effect.FlushlessClear(rootId.CreateChild(id));
     }
     
     private void CleanUp()


### PR DESCRIPTION
## Summary
- Rename \`Effect.ClearNoFlush\` / \`EffectResults.ClearNoFlush\` to \`FlushlessClear\` to align with the existing \`FlushlessUpsert\` / \`FlushlessUpserts\` naming convention.
- Updates the only caller (\`IdempotencyKeys\`).

## Test plan
- [x] \`dotnet build Cleipnir.ResilientFunctions.sln\` — clean
- [x] \`dotnet test Core/Cleipnir.ResilientFunctions.Tests\` — 521 / 521 passing