### PR TITLE
QueueManager: extract fetch-and-deliver pipeline into FetchedMessages

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/Queuing/FetchedMessages.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/FetchedMessages.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.CoreRuntime;
+using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
+using Cleipnir.ResilientFunctions.Domain;
+using Cleipnir.ResilientFunctions.Messaging;
+using Cleipnir.ResilientFunctions.Storage;
+
+namespace Cleipnir.ResilientFunctions.Queuing;
+
+internal class FetchedMessages
+{
+    private const int ReservedIdPrefix = -1;
+    private static readonly EffectId PendingDeletionsRoot = new([ReservedIdPrefix, 0]);
+    private static EffectId          PendingDeletion(int index) => new([ReservedIdPrefix, 0, index]);
+    private static readonly EffectId IdempotencyKeysRoot   = new([ReservedIdPrefix, -1]);
+
+    private readonly FlowId _flowId;
+    private readonly StoredId _storedId;
+    private readonly IMessageStore _messageStore;
+    private readonly ISerializer _serializer;
+    private readonly Effect _effect;
+    private readonly FlowState _flowState;
+    private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
+    private readonly FlowTimeouts _timeouts;
+    private readonly SettingsWithDefaults _settings;
+    private readonly IdempotencyKeys _idempotencyKeys;
+
+    private readonly SemaphoreSlim _semaphore = new(1);
+    private readonly Lock _lock = new();
+    private readonly List<MessageData> _toDeliver = new();
+    private readonly HashSet<long> _fetchedPositions = new();
+    private readonly List<Subscription> _subscriptions = new();
+    private int _nextToRemoveIndex;
+    private volatile Exception? _thrownException;
+
+    public Exception? ThrownException => _thrownException;
+
+    public FetchedMessages(
+        FlowId flowId,
+        StoredId storedId,
+        IMessageStore messageStore,
+        ISerializer serializer,
+        Effect effect,
+        FlowState flowState,
+        UnhandledExceptionHandler unhandledExceptionHandler,
+        FlowTimeouts timeouts,
+        UtcNow utcNow,
+        SettingsWithDefaults settings,
+        int maxIdempotencyKeyCount,
+        TimeSpan? maxIdempotencyKeyTtl)
+    {
+        _flowId = flowId;
+        _storedId = storedId;
+        _messageStore = messageStore;
+        _serializer = serializer;
+        _effect = effect;
+        _flowState = flowState;
+        _unhandledExceptionHandler = unhandledExceptionHandler;
+        _timeouts = timeouts;
+        _settings = settings;
+        _idempotencyKeys = new IdempotencyKeys(IdempotencyKeysRoot, _effect, maxIdempotencyKeyCount, maxIdempotencyKeyTtl, utcNow);
+    }
+
+    public async Task Initialize()
+    {
+        _idempotencyKeys.Initialize();
+
+        _nextToRemoveIndex = await _effect.CreateOrGet(PendingDeletionsRoot, 0, alias: null, flush: false);
+        var children = _effect.GetChildren(PendingDeletionsRoot);
+        var positions = new List<long>();
+        foreach (var childId in children)
+        {
+            var position = _effect.Get<long>(childId);
+            positions.Add(position);
+        }
+
+        if (positions.Any())
+        {
+            await _messageStore.DeleteMessages(_storedId, positions);
+            foreach (var childId in children)
+                await _effect.Clear(childId, flush: false);
+        }
+    }
+
+    public async Task FetchOnce()
+    {
+        await _semaphore.WaitAsync();
+        try
+        {
+            if (_thrownException != null)
+                return;
+
+            List<long> skipPositions;
+            lock (_lock)
+                skipPositions = _fetchedPositions.ToList();
+
+            var messages = await _messageStore.GetMessages(_storedId, skipPositions);
+            foreach (var (messageContent, messageType, position, idempotencyKey, sender, receiver) in messages)
+            {
+                try
+                {
+                    var msg = _serializer.Deserialize(messageContent, _serializer.ResolveType(messageType)!);
+
+                    if (idempotencyKey != null && !_idempotencyKeys.Add(idempotencyKey, position))
+                    {
+                        await _messageStore.DeleteMessages(_storedId, [position]);
+                        continue;
+                    }
+
+                    var envelope = new Envelope(msg, receiver, sender);
+                    var messageData = new MessageData(
+                        envelope,
+                        position,
+                        messageContent,
+                        messageType,
+                        receiver,
+                        sender
+                    );
+                    lock (_lock)
+                    {
+                        _toDeliver.Add(messageData);
+                        _fetchedPositions.Add(position);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _unhandledExceptionHandler.Invoke(_flowId.Type, e);
+                    _thrownException = e;
+                    FailAllSubscriptions(e);
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            TryDispatch();
+            _semaphore.Release();
+        }
+    }
+
+    public async Task<MatchResult?> WaitForMessageOrTimeout(EffectId timeoutId, MessagePredicate predicate, DateTime? timeout)
+    {
+        var subscription = new Subscription(predicate, timeout);
+
+        lock (_lock)
+            _subscriptions.Add(subscription);
+
+        TryDispatch();
+
+        var waitTask = timeout != null
+            ? _timeouts.AddTimeout(timeoutId, timeout.Value)
+            : Task.Delay(_settings.MessagesDefaultMaxWaitForCompletion);
+
+        _flowState.SubflowWaiting();
+        await Task.WhenAny(subscription.Tcs.Task, waitTask);
+        var success = _flowState.ResumeSubflow();
+        if (!success)
+            await new TaskCompletionSource().Task;
+
+        lock (_lock)
+        {
+            var stillRegistered = _subscriptions.Remove(subscription);
+            if (stillRegistered)
+                subscription.Tcs.TrySetResult(null);
+        }
+
+        var result = await subscription.Tcs.Task;
+        if (result != null)
+            _timeouts.RemoveTimeout(timeoutId);
+
+        return result;
+    }
+
+    public async Task AfterFlush()
+    {
+        await _semaphore.WaitAsync();
+        try
+        {
+            var children = _effect.GetChildren(PendingDeletionsRoot);
+            var nonDirtyChildren = new List<EffectId>();
+            foreach (var childId in children)
+                if (!_effect.IsDirty(childId))
+                    nonDirtyChildren.Add(childId);
+
+            if (nonDirtyChildren.Any())
+            {
+                var positions = new List<long>();
+                foreach (var nonDirtyChild in nonDirtyChildren)
+                {
+                    var position = _effect.Get<long>(nonDirtyChild);
+                    positions.Add(position);
+                }
+
+                await _messageStore.DeleteMessages(_storedId, positions);
+                foreach (var nonDirtyChild in nonDirtyChildren)
+                    await _effect.Clear(nonDirtyChild, flush: false);
+
+                lock (_lock)
+                    foreach (var position in positions)
+                        _fetchedPositions.Remove(position);
+            }
+        }
+        catch (Exception exception)
+        {
+            _unhandledExceptionHandler.Invoke(_flowId.Type, exception);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private void TryDispatch()
+    {
+        lock (_lock)
+            for (var subscriptionIndex = 0; subscriptionIndex < _subscriptions.Count; subscriptionIndex++)
+            {
+                var subscription = _subscriptions[subscriptionIndex];
+                for (var matchIndex = 0; matchIndex < _toDeliver.Count; matchIndex++)
+                    if (subscription.Predicate(_toDeliver[matchIndex].Envelope))
+                    {
+                        var msg = _toDeliver[matchIndex];
+                        _toDeliver.RemoveAt(matchIndex);
+                        var positionToRemoveIndex = _nextToRemoveIndex++;
+                        var toRemoveId = PendingDeletion(positionToRemoveIndex);
+                        _effect.FlushlessUpsert(PendingDeletionsRoot, _nextToRemoveIndex, alias: null);
+                        _subscriptions.RemoveAt(subscriptionIndex);
+                        subscription.Tcs.TrySetResult(new MatchResult(msg, toRemoveId));
+                        TryDispatch();
+                        return;
+                    }
+            }
+    }
+
+    private void FailAllSubscriptions(Exception exception)
+    {
+        lock (_lock)
+        {
+            foreach (var sub in _subscriptions)
+                sub.Tcs.TrySetException(exception);
+            _subscriptions.Clear();
+        }
+    }
+
+    public record MessageData(
+        Envelope Envelope,
+        long Position,
+        byte[] MessageContentBytes,
+        byte[] MessageTypeBytes,
+        string? Receiver,
+        string? Sender
+    );
+
+    public record MatchResult(MessageData Message, EffectId ToRemoveId);
+
+    private record Subscription(MessagePredicate Predicate, DateTime? Timeout)
+    {
+        public TaskCompletionSource<MatchResult?> Tcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Domain.Exceptions.Commands;
-using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Storage;
 
@@ -17,36 +14,16 @@ public delegate bool MessagePredicate(Envelope envelope);
 
 public class QueueManager : IDisposable
 {
-    private const int ReservedIdPrefix = -1;
-
-    private readonly FlowId _flowId;
-    private readonly StoredId _storedId;
-    private readonly IMessageStore _messageStore;
-    private readonly ISerializer _serializer;
     private readonly Effect _effect;
     private readonly FlowState _flowState;
-    private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
-    private readonly FlowTimeouts _timeouts;
+    private readonly ISerializer _serializer;
     private readonly UtcNow _utcNow;
     private readonly SettingsWithDefaults _settings;
+    private readonly FetchedMessages _fetchedMessages;
 
-    private readonly Lock _lock = new();
-
-    private static readonly EffectId PendingDeletionsRoot = new([ReservedIdPrefix, 0]);
-    private static EffectId          PendingDeletion(int index) => new([ReservedIdPrefix, 0, index]);
-    private static readonly EffectId IdempotencyKeysRoot   = new([ReservedIdPrefix, -1]);
-
-    private readonly List<MessageData> _toDeliver = new();
-    private readonly HashSet<long> _fetchedPositions = new();
-    private readonly List<Subscription> _subscriptions = new();
-
-    private readonly IdempotencyKeys _idempotencyKeys;
-    private int _nextToRemoveIndex = 0;
-    private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1);
-    private bool _initialized = false;
+    private readonly SemaphoreSlim _semaphoreSlim = new(1);
+    private bool _initialized;
     private volatile bool _disposed;
-
-    private volatile Exception? _thrownException = null;
 
     public QueueManager(
         FlowId flowId,
@@ -62,18 +39,25 @@ public class QueueManager : IDisposable
         int maxIdempotencyKeyCount = 100,
         TimeSpan? maxIdempotencyKeyTtl = null)
     {
-        _flowId = flowId;
-        _storedId = storedId;
-        _messageStore = messageStore;
-        _serializer = serializer;
         _effect = effect;
         _flowState = flowState;
-        _unhandledExceptionHandler = unhandledExceptionHandler;
-        _timeouts = timeouts;
+        _serializer = serializer;
         _utcNow = utcNow;
         _settings = settings;
-
-        _idempotencyKeys = new IdempotencyKeys(IdempotencyKeysRoot, _effect, maxIdempotencyKeyCount, maxIdempotencyKeyTtl, _utcNow);
+        _fetchedMessages = new FetchedMessages(
+            flowId,
+            storedId,
+            messageStore,
+            serializer,
+            effect,
+            flowState,
+            unhandledExceptionHandler,
+            timeouts,
+            utcNow,
+            settings,
+            maxIdempotencyKeyCount,
+            maxIdempotencyKeyTtl
+        );
     }
 
     private async Task Initialize()
@@ -88,23 +72,7 @@ public class QueueManager : IDisposable
                 return;
 
             _effect.RegisterQueueManager(this);
-            _idempotencyKeys.Initialize();
-
-            _nextToRemoveIndex = await _effect.CreateOrGet(PendingDeletionsRoot, 0, alias: null, flush: false);
-            var children = _effect.GetChildren(PendingDeletionsRoot);
-            var positions = new List<long>();
-            foreach (var childId in children)
-            {
-                var position = _effect.Get<long>(childId);
-                positions.Add(position);
-            }
-
-            if (positions.Any())
-            {
-                await _messageStore.DeleteMessages(_storedId, positions);
-                foreach (var childId in children)
-                    await _effect.Clear(childId, flush: false);
-            }
+            await _fetchedMessages.Initialize();
 
             _initialized = true;
         }
@@ -123,178 +91,14 @@ public class QueueManager : IDisposable
         return new QueueClient(this, _serializer, _utcNow);
     }
 
-    public async Task FetchMessagesOnce()
+    public Task FetchMessagesOnce()
     {
         if (_disposed)
             throw new ObjectDisposedException($"{nameof(QueueManager)} is disposed already");
-
-        await _semaphoreSlim.WaitAsync();
-        try
-        {
-            if (_thrownException != null)
-                return;
-
-            List<long> skipPositions;
-            lock (_lock)
-                skipPositions = _fetchedPositions.ToList();
-
-            var messages = await _messageStore.GetMessages(_storedId, skipPositions);
-            foreach (var (messageContent, messageType, position, idempotencyKey, sender, receiver) in messages)
-            {
-                try
-                {
-                    var msg = _serializer.Deserialize(messageContent, _serializer.ResolveType(messageType)!);
-
-                    if (idempotencyKey != null && !_idempotencyKeys.Add(idempotencyKey, position))
-                    {
-                        await _messageStore.DeleteMessages(_storedId, [position]);
-                        continue;
-                    }
-
-                    var envelope = new Envelope(msg, receiver, sender);
-                    var messageData = new MessageData(
-                        envelope,
-                        position,
-                        messageContent,
-                        messageType,
-                        receiver,
-                        sender
-                    );
-                    lock (_lock)
-                    {
-                        _toDeliver.Add(messageData);
-                        _fetchedPositions.Add(position);
-                    }
-                }
-                catch (Exception e)
-                {
-                    _unhandledExceptionHandler.Invoke(_flowId.Type, e);
-                    _thrownException = e;
-                    FailAllSubscriptions(e);
-                    return;
-                }
-            }
-        }
-        finally
-        {
-            TryDispatch();
-            _semaphoreSlim.Release();
-        }
+        return _fetchedMessages.FetchOnce();
     }
 
-    private void TryDispatch()
-    {
-        lock (_lock)
-            for (var subscriptionIndex = 0; subscriptionIndex < _subscriptions.Count; subscriptionIndex++)
-            {
-                var subscription = _subscriptions[subscriptionIndex];
-                for (var matchIndex = 0; matchIndex < _toDeliver.Count; matchIndex++)
-                    if (subscription.Predicate(_toDeliver[matchIndex].Envelope))
-                    {
-                        var msg = _toDeliver[matchIndex];
-                        _toDeliver.RemoveAt(matchIndex);
-                        var positionToRemoveIndex = _nextToRemoveIndex++;
-                        _effect.FlushlessUpsert(PendingDeletionsRoot, _nextToRemoveIndex, alias: null);
-                        _subscriptions.RemoveAt(subscriptionIndex);
-                        subscription.Tcs.TrySetResult(new MatchResult(msg, positionToRemoveIndex));
-                        TryDispatch();
-                        return;
-                    }
-            }
-    }
-
-    private void FailAllSubscriptions(Exception exception)
-    {
-        lock (_lock)
-        {
-            foreach (var sub in _subscriptions)
-                sub.Tcs.TrySetException(exception);
-            _subscriptions.Clear();
-        }
-    }
-
-    private async Task FetchLoop()
-    {
-        while (!_disposed && _thrownException == null)
-        {
-            await FetchMessagesOnce();
-            await Task.WhenAny(
-                _flowState.InterruptSignal.Wait(),
-                Task.Delay(_settings.MessagesPullFrequency));
-        }
-    }
-
-    public async Task AfterFlush()
-    {
-        await _semaphoreSlim.WaitAsync();
-        try
-        {
-            var children = _effect.GetChildren(PendingDeletionsRoot);
-            var nonDirtyChildren = new List<EffectId>();
-            foreach (var childId in children)
-                if (!_effect.IsDirty(childId))
-                    nonDirtyChildren.Add(childId);
-
-            if (nonDirtyChildren.Any())
-            {
-                var positions = new List<long>();
-                foreach (var nonDirtyChild in nonDirtyChildren)
-                {
-                    var position = _effect.Get<long>(nonDirtyChild);
-                    positions.Add(position);
-                }
-
-                await _messageStore.DeleteMessages(_storedId, positions);
-                foreach (var nonDirtyChild in nonDirtyChildren)
-                    await _effect.Clear(nonDirtyChild, flush: false);
-
-                lock (_lock)
-                    foreach (var position in positions)
-                        _fetchedPositions.Remove(position);
-            }
-        }
-        catch (Exception exception)
-        {
-            _unhandledExceptionHandler.Invoke(_flowId.Type, exception);
-        }
-        finally
-        {
-            _semaphoreSlim.Release();
-        }
-    }
-
-    private async Task<MatchResult?> WaitForMessageOrTimeout(EffectId timeoutId, MessagePredicate predicate, DateTime? timeout)
-    {
-        var subscription = new Subscription(predicate, timeout);
-
-        lock (_lock)
-            _subscriptions.Add(subscription);
-
-        TryDispatch();
-
-        var waitTask = timeout != null
-            ? _timeouts.AddTimeout(timeoutId, timeout.Value)
-            : Task.Delay(_settings.MessagesDefaultMaxWaitForCompletion);
-
-        _flowState.SubflowWaiting();
-        await Task.WhenAny(subscription.Tcs.Task, waitTask);
-        var success = _flowState.ResumeSubflow();
-        if (!success)
-            await new TaskCompletionSource().Task;
-
-        lock (_lock)
-        {
-            var stillRegistered = _subscriptions.Remove(subscription);
-            if (stillRegistered)
-                subscription.Tcs.TrySetResult(null);
-        }
-
-        var result = await subscription.Tcs.Task;
-        if (result != null)
-            _timeouts.RemoveTimeout(timeoutId);
-
-        return result;
-    }
+    public Task AfterFlush() => _fetchedMessages.AfterFlush();
 
     public async Task<Envelope?> Subscribe(
         MessagePredicate predicate,
@@ -305,23 +109,22 @@ public class QueueManager : IDisposable
         EffectId receiverId,
         EffectId senderId)
     {
-        if (_thrownException != null)
-            throw _thrownException;
+        if (_fetchedMessages.ThrownException is { } pre)
+            throw pre;
 
         await FetchMessagesOnce();
 
-        var matched = await WaitForMessageOrTimeout(timeoutId, predicate, timeout);
+        var matched = await _fetchedMessages.WaitForMessageOrTimeout(timeoutId, predicate, timeout);
 
-        if (_thrownException != null)
-            throw _thrownException;
+        if (_fetchedMessages.ThrownException is { } post)
+            throw post;
 
         if (matched == null)
             return timeout != null ? null : throw new SuspendInvocationException();
 
-        var toRemoveId = PendingDeletion(matched.PositionToRemoveIndex);
         _effect.FlushlessUpserts(
         [
-            new EffectResult(toRemoveId, matched.Message.Position, Alias: null),
+            new EffectResult(matched.ToRemoveId, matched.Message.Position, Alias: null),
             new EffectResult(messageId, matched.Message.MessageContentBytes, Alias: null),
             new EffectResult(messageTypeId, matched.Message.MessageTypeBytes, Alias: null),
             new EffectResult(receiverId, matched.Message.Receiver, Alias: null),
@@ -331,20 +134,15 @@ public class QueueManager : IDisposable
         return matched.Message.Envelope;
     }
 
-    public record MessageData(
-        Envelope Envelope,
-        long Position,
-        byte[] MessageContentBytes,
-        byte[] MessageTypeBytes,
-        string? Receiver,
-        string? Sender
-    );
-
-    private record MatchResult(MessageData Message, int PositionToRemoveIndex);
-
-    private record Subscription(MessagePredicate Predicate, DateTime? Timeout)
+    private async Task FetchLoop()
     {
-        public TaskCompletionSource<MatchResult?> Tcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        while (!_disposed && _fetchedMessages.ThrownException == null)
+        {
+            await FetchMessagesOnce();
+            await Task.WhenAny(
+                _flowState.InterruptSignal.Wait(),
+                Task.Delay(_settings.MessagesPullFrequency));
+        }
     }
 
     public void Dispose() => _disposed = true;


### PR DESCRIPTION
## Summary
- Move buffer state, fetching, dispatching, subscription waiting, and pending-deletions persistence out of \`QueueManager\` into a new internal \`FetchedMessages\` type.
- \`FetchedMessages\` owns: \`_toDeliver\`, \`_fetchedPositions\`, \`_subscriptions\`, \`_nextToRemoveIndex\`, \`_thrownException\`, the fetch \`SemaphoreSlim\`, the reserved \`EffectId\` constants (\`PendingDeletionsRoot\`, \`PendingDeletion(int)\`, \`IdempotencyKeysRoot\`), and the \`IdempotencyKeys\` instance.
- \`FetchedMessages\` exposes: \`Initialize\`, \`FetchOnce\`, \`WaitForMessageOrTimeout\`, \`AfterFlush\`, and a \`ThrownException\` property for fast-fail.
- \`QueueManager\` becomes a thin orchestrator: lifecycle (\`Initialize\` / \`Dispose\` / \`FetchLoop\` / \`CreateQueueClient\`), public delegates (\`FetchMessagesOnce\` with disposed-check, \`AfterFlush\`), and the \`Subscribe\` public API which composes \`WaitForMessageOrTimeout\` with the post-match \`Effect.FlushlessUpserts\` for the per-message slot IDs.
- \`MatchResult\` now carries the resolved \`EffectId ToRemoveId\` directly, so \`QueueManager\` no longer needs to know about the \`PendingDeletion(int)\` indexing scheme.
- \`MessageData\` moved with the pipeline (now nested in \`FetchedMessages\`); no external callers were affected.

## Test plan
- [x] \`dotnet build Core/Cleipnir.ResilientFunctions\` — clean
- [x] \`dotnet test Core/Cleipnir.ResilientFunctions.Tests\` — 521 / 521 passing