### PR TITLE
Add InterruptedWatchdog scaffolding

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
@@ -251,12 +251,12 @@ public class StoreTests : TestTemplates.StoreTests
         => GetInterruptedFunctionsReturnsEmptyListWhenNoneFunctionsAreInterrupted(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist()
-        => GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes()
+        => GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions()
-        => GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction()
+        => GetInterruptedFunctionsIncludesPostponedInterruptedFunction(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task GetResultsReturnsResultsForExistingFunctions()

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -560,7 +560,7 @@ public abstract class MessagesSubscriptionTests
             {
 
                 var flowTimeouts = new FlowTimeouts();
-                var flowsManager = new FlowsManager(functionStore);
+                var flowsManager = new FlowsManager();
                 var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
@@ -623,7 +623,7 @@ public abstract class MessagesSubscriptionTests
             {
                 storedId = workflow.StoredId;
                 var minimumTimeout = new FlowTimeouts();
-                var flowsManager = new FlowsManager(functionStore);
+                var flowsManager = new FlowsManager();
                 var flowState = flowsManager.CreateFlow(workflow.StoredId, minimumTimeout);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
@@ -684,7 +684,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
             {
 
                 var flowTimeouts = new FlowTimeouts();
-                var flowsManager = new FlowsManager(functionStore);
+                var flowsManager = new FlowsManager();
                 var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
                 var queueManager = new QueueManager(
                     workflow.FlowId,

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
@@ -332,7 +332,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
 
         effect.TryGet<int>("alias", out _).ShouldBeFalse();
 
@@ -380,7 +380,7 @@ public abstract class EffectTests
             storageSession: null,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
 
         // Verify the effect is immediately available (eager loading)
         effect.TryGet<int>("test_alias", out var result).ShouldBeTrue();
@@ -714,7 +714,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(store), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
 
         var result = await effect.Capture(() => "hello world", ResiliencyLevel.AtLeastOnceDelayFlush);
         result.ShouldBe("hello world");

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -2107,18 +2107,15 @@ public abstract class StoreTests
         interruptedFunctions.Count.ShouldBe(0);
     }
 
-    public abstract Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist();
-    protected async Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist(Task<IFunctionStore> storeTask)
+    public abstract Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes();
+    protected async Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes(Task<IFunctionStore> storeTask)
     {
         var store = await storeTask;
-        var functionId1 = TestStoredId.Create();
-        var functionId2 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
-        var nonExistentId1 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
-        var nonExistentId2 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
+        var functionId = TestStoredId.Create();
 
         var session = await store.CreateFunction(
-            functionId1,
-            "humanInstanceId1",
+            functionId,
+            "humanInstanceId",
             param: Test.SimpleStoredParameter,
             leaseExpiration: DateTime.UtcNow.Ticks,
             postponeUntil: null,
@@ -2128,43 +2125,25 @@ public abstract class StoreTests
         );
         session.ShouldBeNull();
 
-        session = await store.CreateFunction(
-            functionId2,
-            "humanInstanceId2",
-            param: Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: null
-        );
-        session.ShouldBeNull();
+        await store.Interrupt(functionId).ShouldBeTrueAsync();
+        await store.Interrupt(functionId).ShouldBeTrueAsync();
+        await store.Interrupt(functionId).ShouldBeTrueAsync();
 
-        await store.Interrupt(functionId1).ShouldBeTrueAsync();
-        await store.Interrupt(functionId2).ShouldBeTrueAsync();
-
-        // No functions are interrupted despite existing
         var interruptedFunctions = await store.GetInterruptedFunctions();
-
-        // Should return the 2 interrupted functions
-        interruptedFunctions.Count.ShouldBe(2);
-        interruptedFunctions.Any(id => id == functionId1).ShouldBeTrue();
-        interruptedFunctions.Any(id => id == functionId2).ShouldBeTrue();
+        interruptedFunctions.Count.ShouldBe(1);
+        interruptedFunctions.Single().ShouldBe(functionId);
     }
 
-    public abstract Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions();
-    protected async Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions(Task<IFunctionStore> storeTask)
+    public abstract Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction();
+    protected async Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction(Task<IFunctionStore> storeTask)
     {
         var store = await storeTask;
-        var functionId1 = TestStoredId.Create();
-        var functionId2 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
-        var functionId3 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
-        var functionId4 = StoredId.Create(functionId1.Type, Guid.NewGuid().ToString());
+        var executingId = TestStoredId.Create();
+        var postponedId = StoredId.Create(executingId.Type, Guid.NewGuid().ToString());
 
-        // Create 4 functions
         var session = await store.CreateFunction(
-            functionId1,
-            "humanInstanceId1",
+            executingId,
+            "humanInstanceId-exec",
             param: Test.SimpleStoredParameter,
             leaseExpiration: DateTime.UtcNow.Ticks,
             postponeUntil: null,
@@ -2175,56 +2154,24 @@ public abstract class StoreTests
         session.ShouldBeNull();
 
         session = await store.CreateFunction(
-            functionId2,
-            "humanInstanceId2",
+            postponedId,
+            "humanInstanceId-postponed",
             param: Test.SimpleStoredParameter,
             leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
+            postponeUntil: DateTime.UtcNow.Ticks,
             timestamp: DateTime.UtcNow.Ticks,
             parent: null,
             owner: null
         );
         session.ShouldBeNull();
 
-        session = await store.CreateFunction(
-            functionId3,
-            "humanInstanceId3",
-            param: Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: null
-        );
-        session.ShouldBeNull();
+        await store.Interrupt(executingId).ShouldBeTrueAsync();
+        await store.Interrupt(postponedId).ShouldBeTrueAsync();
 
-        session = await store.CreateFunction(
-            functionId4,
-            "humanInstanceId4",
-            param: Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: null
-        );
-        session.ShouldBeNull();
-
-        // Interrupt all 4 functions
-        await store.Interrupt(functionId1).ShouldBeTrueAsync();
-        await store.Interrupt(functionId2).ShouldBeTrueAsync();
-        await store.Interrupt(functionId3).ShouldBeTrueAsync();
-        await store.Interrupt(functionId4).ShouldBeTrueAsync();
-
-        // Get all interrupted functions
         var interruptedFunctions = await store.GetInterruptedFunctions();
-
-        // Should return all 4 interrupted functions
-        interruptedFunctions.Count.ShouldBe(4);
-        interruptedFunctions.Any(id => id == functionId1).ShouldBeTrue();
-        interruptedFunctions.Any(id => id == functionId2).ShouldBeTrue();
-        interruptedFunctions.Any(id => id == functionId3).ShouldBeTrue();
-        interruptedFunctions.Any(id => id == functionId4).ShouldBeTrue();
+        interruptedFunctions.Count.ShouldBe(2);
+        interruptedFunctions.Any(id => id == executingId).ShouldBeTrue();
+        interruptedFunctions.Any(id => id == postponedId).ShouldBeTrue();
     }
 
     public abstract Task GetResultsReturnsResultsForExistingFunctions();

--- a/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
@@ -43,7 +43,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1]\n";
@@ -75,7 +75,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1] my-effect\n";
@@ -111,7 +111,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✗ [1] failed-operation (System.InvalidOperationException)\n";
@@ -143,7 +143,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected = "└─ ⋯ [1] in-progress\n";
@@ -189,7 +189,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -245,7 +245,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -295,7 +295,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -330,7 +330,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -365,7 +365,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =
@@ -398,7 +398,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(new InMemoryFunctionStore()), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
         var output = effect.ExecutionTree();
 
         var expected =

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -62,6 +62,13 @@ public class FlowState
 
     public void Interrupt()
     {
+        lock (_lock)
+            if (Suspended)
+                return;
+            else
+                WaitingSubflows = 0;
+        
+        InterruptSignal.Fire();
     }
 
     public bool Suspend()

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -62,13 +62,6 @@ public class FlowState
 
     public void Interrupt()
     {
-        lock (_lock)
-            if (Suspended)
-                return;
-            else
-                WaitingSubflows = 0;
-        
-        InterruptSignal.Fire();
     }
 
     public bool Suspend()

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -6,7 +6,7 @@ using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
 
-public class FlowsManager(IFunctionStore functionStore)
+public class FlowsManager
 {
     private readonly Dictionary<StoredId, FlowState> _dict = new();
     private readonly Lock _lock = new();
@@ -32,11 +32,13 @@ public class FlowsManager(IFunctionStore functionStore)
 
     public Task Interrupt(IReadOnlyList<StoredId> ids)
     {
-        lock (_lock)
-            foreach (var id in ids)
-                if (_dict.TryGetValue(id, out var flowState))
-                    flowState.Interrupt();
+        /*
+         * lock (_lock)
+           foreach (var id in ids)
+               if (_dict.TryGetValue(id, out var flowState))
+                   flowState.Interrupt();
 
+         */
         return Task.CompletedTask;
     }
 

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Storage;
@@ -23,14 +24,20 @@ public class FlowsManager(IFunctionStore functionStore)
               _dict.Remove(id);
     }
 
-    public async Task Interrupt(IReadOnlyList<StoredId> ids)
+    public IReadOnlyList<StoredId> FilterOwned(IEnumerable<StoredId> ids)
     {
-        await functionStore.ResetInterrupted(ids);
+        lock (_lock)
+            return ids.Where(_dict.ContainsKey).ToList();
+    }
 
+    public Task Interrupt(IReadOnlyList<StoredId> ids)
+    {
         lock (_lock)
             foreach (var id in ids)
                 if (_dict.TryGetValue(id, out var flowState))
                     flowState.Interrupt();
+
+        return Task.CompletedTask;
     }
 
     public void StartThread(StoredId id)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/InterruptedWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/InterruptedWatchdog.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Domain;
+using Cleipnir.ResilientFunctions.Domain.Exceptions;
+using Cleipnir.ResilientFunctions.Helpers;
+using Cleipnir.ResilientFunctions.Storage;
+
+namespace Cleipnir.ResilientFunctions.CoreRuntime.Watchdogs;
+
+internal class InterruptedWatchdog
+{
+    private readonly IFunctionStore _functionStore;
+    private readonly FlowsManager _flowsManager;
+    private readonly ShutdownCoordinator _shutdownCoordinator;
+    private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
+    private readonly TimeSpan _checkFrequency;
+    private readonly TimeSpan _delayStartUp;
+    private readonly UtcNow _utcNow;
+
+    public InterruptedWatchdog(
+        IFunctionStore functionStore,
+        FlowsManager flowsManager,
+        ShutdownCoordinator shutdownCoordinator,
+        UnhandledExceptionHandler unhandledExceptionHandler,
+        TimeSpan checkFrequency,
+        TimeSpan delayStartUp,
+        UtcNow utcNow)
+    {
+        _functionStore = functionStore;
+        _flowsManager = flowsManager;
+        _shutdownCoordinator = shutdownCoordinator;
+        _unhandledExceptionHandler = unhandledExceptionHandler;
+        _checkFrequency = checkFrequency;
+        _delayStartUp = delayStartUp;
+        _utcNow = utcNow;
+    }
+
+    public async Task Start()
+    {
+        await Task.Delay(_delayStartUp);
+
+        Start:
+        try
+        {
+            while (!_shutdownCoordinator.ShutdownInitiated)
+            {
+                var now = _utcNow();
+
+                var interrupted = await _functionStore.GetInterruptedFunctions();
+                var owned = _flowsManager.FilterOwned(interrupted);
+                if (owned.Count > 0)
+                    await _flowsManager.Interrupt(owned);
+
+                var timeElapsed = _utcNow() - now;
+                var delay = (_checkFrequency - timeElapsed).RoundUpToZero();
+
+                await Task.Delay(delay);
+            }
+        }
+        catch (Exception thrownException)
+        {
+            _unhandledExceptionHandler.Invoke(
+                new FrameworkException(
+                    $"{nameof(InterruptedWatchdog)} execution failed - retrying in 5 seconds",
+                    innerException: thrownException
+                )
+            );
+
+            await Task.Delay(5_000);
+            goto Start;
+        }
+    }
+}

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -31,6 +31,7 @@ public class FunctionsRegistry : IDisposable
     private volatile bool _disposed;
     private readonly Lock _sync = new();
     private readonly ReplicaWatchdog _replicaWatchdog;
+    private readonly InterruptedWatchdog _interruptedWatchdog;
     private readonly FlowsManager _flowsManager;
 
     public FunctionsRegistry(IFunctionStore functionStore, Settings? settings = null)
@@ -61,10 +62,22 @@ public class FunctionsRegistry : IDisposable
             utcNow, 
             _settings.UnhandledExceptionHandler
         );
+
+        _interruptedWatchdog = new InterruptedWatchdog(
+            _functionStore,
+            _flowsManager,
+            _shutdownCoordinator,
+            _settings.UnhandledExceptionHandler,
+            _settings.WatchdogCheckFrequency,
+            _settings.DelayStartup,
+            utcNow
+        );
+
         if (_settings.EnableWatchdogs)
         {
             _replicaWatchdog.Initialize().GetAwaiter().GetResult();
             _ = _replicaWatchdog.Start();            
+            _ = Task.Run(_interruptedWatchdog.Start);
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -41,7 +41,7 @@ public class FunctionsRegistry : IDisposable
         _shutdownCoordinator = new ShutdownCoordinator();
         _settings = SettingsWithDefaults.Default.Merge(settings);
         var utcNow = _settings.UtcNow;
-        _flowsManager = new FlowsManager(_functionStore);
+        _flowsManager = new FlowsManager();
         
         ClusterInfo = new ClusterInfo(ReplicaId.NewId());
         

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
@@ -240,12 +240,12 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => GetInterruptedFunctionsReturnsEmptyListWhenNoneFunctionsAreInterrupted(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist()
-        => GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes()
+        => GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions()
-        => GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction()
+        => GetInterruptedFunctionsIncludesPostponedInterruptedFunction(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task GetResultsReturnsResultsForExistingFunctions()

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -71,7 +71,7 @@ public class MariaDbFunctionStore : IFunctionStore
                 owner CHAR(32) NULL,
                 effects LONGBLOB NULL,
                 INDEX (expires, id, status),
-                INDEX idx_interrupted (id, interrupted)
+                INDEX idx_interrupted (interrupted, id)
             );";
 
         await using var command = new MySqlCommand(_initializeSql, conn);

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
@@ -243,12 +243,12 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => GetInterruptedFunctionsReturnsEmptyListWhenNoneFunctionsAreInterrupted(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist()
-        => GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes()
+        => GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions()
-        => GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction()
+        => GetInterruptedFunctionsIncludesPostponedInterruptedFunction(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task GetResultsReturnsResultsForExistingFunctions()

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
@@ -243,12 +243,12 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => GetInterruptedFunctionsReturnsEmptyListWhenNoneFunctionsAreInterrupted(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist()
-        => GetInterruptedFunctionsReturnsEmptyListWhenQueriedIdsDoNotExist(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes()
+        => GetInterruptedFunctionsReturnsIdOnceWhenInterruptedMultipleTimes(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions()
-        => GetInterruptedFunctionsOnlyReturnsMatchingInterruptedFunctions(FunctionStoreFactory.Create());
+    public override Task GetInterruptedFunctionsIncludesPostponedInterruptedFunction()
+        => GetInterruptedFunctionsIncludesPostponedInterruptedFunction(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task GetResultsReturnsResultsForExistingFunctions()


### PR DESCRIPTION
## Summary
- New `InterruptedWatchdog` that polls `GetInterruptedFunctions` and calls `FlowsManager.Interrupt` with the subset owned by this replica (present in `FlowsManager`'s in-memory dict).
- Adds `FlowsManager.FilterOwned(ids)` so the watchdog can scope to locally-running flows under the existing lock.
- Wired into `FunctionsRegistry` ctor, started under `EnableWatchdogs`. Shutdown via existing `ShutdownCoordinator`.

## Note on stubs
`FlowState.Interrupt` and `FlowsManager.Interrupt`'s `ResetInterrupted` call are stubbed for now. The earlier implementations raced with `SuspendFunction`: when the watchdog cleared the persistent `Interrupted` flag mid-flight (after `AppendMessage` set it, before `SuspendFunction` read it), the flow transitioned to `Suspended` instead of `Postponed` and never restarted. Scaffolding is in place; semantics can be re-introduced once the suspend-design direction lands.

## Test plan
- [x] In-memory test suite (451 tests) passes in ~20s with the new watchdog wired in