### PR TITLE
Fail Suspend/Postpone when function is currently interrupted

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/RFunctionTests/DelayedStartUpTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/RFunctionTests/DelayedStartUpTests.cs
@@ -114,6 +114,7 @@ public class DelayedStartUpTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
         
@@ -154,6 +155,7 @@ public class DelayedStartUpTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         );
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/ShutdownCoordinationTests/RFunctionsShutdownTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/ShutdownCoordinationTests/RFunctionsShutdownTests.cs
@@ -187,6 +187,7 @@ public class RFunctionsShutdownTests
             Guid.Empty.ToReplicaId(),
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/InMemoryTests/StoreTests.cs
@@ -127,12 +127,8 @@ public class StoreTests : TestTemplates.StoreTests
         => EpochIsNotIncrementedOnSuspension(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction()
-        => SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction(FunctionStoreFactory.Create());
-
-    [TestMethod]
-    public override Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch()
-        => FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch(FunctionStoreFactory.Create());
+    public override Task SuspendingInterruptedFunctionReturnsFalse()
+        => SuspendingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task InterruptCountCanBeIncrementedForExecutingFunction()
@@ -187,16 +183,16 @@ public class StoreTests : TestTemplates.StoreTests
         => MultipleFunctionsStatusCanBeFetched(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted()
-        => InterruptedFunctionIsNotPostponedToZeroWhenInterrupted(FunctionStoreFactory.Create());
+    public override Task PostponingInterruptedFunctionReturnsFalse()
+        => PostponingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task InterruptNothingWorks()
         => InterruptNothingWorks(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction()
-        => InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction(FunctionStoreFactory.Create());
+    public override Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag()
+        => PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task FunctionCanBeCreatedWithMessagesAndEffects()

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/PostponedTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/PostponedTests.cs
@@ -571,6 +571,7 @@ public abstract class PostponedTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
         

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -927,14 +927,14 @@ public abstract class StoreTests
         storedFunction.ShouldNotBeNull();
     }
     
-    public abstract Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction();
-    protected async Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction(Task<IFunctionStore> storeTask)
+    public abstract Task SuspendingInterruptedFunctionReturnsFalse();
+    protected async Task SuspendingInterruptedFunctionReturnsFalse(Task<IFunctionStore> storeTask)
     {
         var functionId = TestStoredId.Create();
-        
+
         var store = await storeTask;
         await store.CreateFunction(
-            functionId, 
+            functionId,
             "humanInstanceId",
             param: Test.SimpleStoredParameter,
             leaseExpiration: DateTime.UtcNow.Ticks,
@@ -944,13 +944,8 @@ public abstract class StoreTests
             owner: ReplicaId.Empty
         ).ShouldNotBeNullAsync();
 
-        await store.MessageStore.AppendMessage(
-            functionId,
-            new StoredMessage("some message".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
-        );
+        await store.Interrupt(functionId).ShouldBeTrueAsync();
 
-        await store.Interrupt(functionId);
-        
         await store.SuspendFunction(
             functionId,
             timestamp: DateTime.UtcNow.Ticks,
@@ -958,53 +953,11 @@ public abstract class StoreTests
             effects: null,
             messages: null,
             storageSession: null
-        ).ShouldBeTrueAsync();
-        
-        var storedFunction = await store.GetFunction(functionId);
-        storedFunction.ShouldNotBeNull();
-        storedFunction.Status.ShouldBe(Status.Postponed);
-        storedFunction.Expires.ShouldBe(0);
-    }
-    
-    public abstract Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch();
-    protected async Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch(Task<IFunctionStore> storeTask)
-    {
-        var functionId = TestStoredId.Create();
-        
-        var store = await storeTask;
-        await store.CreateFunction(
-            functionId, 
-            "humanInstanceId",
-            param: Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: ReplicaId.Empty
-        ).ShouldNotBeNullAsync();
+        ).ShouldBeFalseAsync();
 
-        await store.MessageStore.AppendMessage(
-            functionId,
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
-        );
-
-        await store.Interrupt(functionId);
-        
-        var success = await store.SuspendFunction(
-            functionId,
-            timestamp: DateTime.UtcNow.Ticks,
-            expectedReplica: ReplicaId.Empty,
-            effects: null,
-            messages: null,
-            storageSession: null
-        );
-        
-        success.ShouldBeTrue();
-        
-        var storedFunction = await store.GetFunction(functionId);
-        storedFunction.ShouldNotBeNull();
-        storedFunction.Status.ShouldBe(Status.Postponed);
-        storedFunction.Expires.ShouldBe(0);
+        var storedFunction = await store.GetFunction(functionId).ShouldNotBeNullAsync();
+        storedFunction.Status.ShouldBe(Status.Executing);
+        (await store.GetInterruptedFunctions()).Any(id => id == functionId).ShouldBeTrue();
     }
     
     public abstract Task InterruptCountCanBeIncrementedForExecutingFunction();
@@ -1411,8 +1364,8 @@ public abstract class StoreTests
         statusAndEpoch2.Status.ShouldBe(Status.Succeeded);
     }
     
-    public abstract Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted();
-    protected async Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted(Task<IFunctionStore> storeTask)
+    public abstract Task PostponingInterruptedFunctionReturnsFalse();
+    protected async Task PostponingInterruptedFunctionReturnsFalse(Task<IFunctionStore> storeTask)
     {
         var storedId = TestStoredId.Create();
         var store = await storeTask;
@@ -1430,20 +1383,19 @@ public abstract class StoreTests
 
         await store.Interrupt([storedId]);
 
-        var success = await store.PostponeFunction(
+        await store.PostponeFunction(
             storedId,
-            postponeUntil: 0,
-            timestamp: 100,
+            postponeUntil: DateTime.UtcNow.Ticks + 100_000,
+            timestamp: DateTime.UtcNow.Ticks,
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
             storageSession: null
-        );
-        success.ShouldBeTrue();
+        ).ShouldBeFalseAsync();
 
         var sf = await store.GetFunction(storedId).ShouldNotBeNullAsync();
-        sf.Status.ShouldBe(Status.Postponed);
-        sf.Expires.ShouldBe(0);
+        sf.Status.ShouldBe(Status.Executing);
+        (await store.GetInterruptedFunctions()).Any(id => id == storedId).ShouldBeTrue();
     }
 
     public abstract Task InterruptNothingWorks();
@@ -1452,9 +1404,9 @@ public abstract class StoreTests
         var store = await storeTask;
         await store.Interrupt(storedIds: []);
     }
-    
-    public abstract Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction();
-    protected async Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction(Task<IFunctionStore> storeTask)
+
+    public abstract Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag();
+    protected async Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag(Task<IFunctionStore> storeTask)
     {
         var storedId = TestStoredId.Create();
         var store = await storeTask;
@@ -1472,19 +1424,21 @@ public abstract class StoreTests
 
         await store.Interrupt([storedId]);
 
-        var success = await store.PostponeFunction(
+        await store.PostponeFunction(
             storedId,
             postponeUntil: 0,
-            timestamp: 0,
+            timestamp: DateTime.UtcNow.Ticks,
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
-            storageSession: null
-        );
-        success.ShouldBeTrue();
+            storageSession: null,
+            failIfInterrupted: false
+        ).ShouldBeTrueAsync();
 
         var sf = await store.GetFunction(storedId).ShouldNotBeNullAsync();
         sf.Status.ShouldBe(Status.Postponed);
+        sf.Expires.ShouldBe(0);
+        (await store.GetInterruptedFunctions()).Any(id => id == storedId).ShouldBeFalse();
     }
     
     public abstract Task FunctionCanBeCreatedWithMessagesAndEffects();

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -244,6 +244,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
         
@@ -281,6 +282,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
         
@@ -318,6 +320,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.NewId(),
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeFalseAsync();
 
@@ -859,6 +862,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         );
         
@@ -1390,6 +1394,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeFalseAsync();
 
@@ -1431,8 +1436,8 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
-            storageSession: null,
-            failIfInterrupted: false
+            failIfInterrupted: false,
+            storageSession: null
         ).ShouldBeTrueAsync();
 
         var sf = await store.GetFunction(storedId).ShouldNotBeNullAsync();
@@ -1902,6 +1907,7 @@ public abstract class StoreTests
             expectedReplica: ReplicaId.Empty,
             effects: null,
             messages: null,
+            failIfInterrupted: true,
             storageSession: null
         ).ShouldBeTrueAsync();
         

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
@@ -131,14 +131,14 @@ public class CrashableFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true
+        bool failIfInterrupted,
+        IStorageSession? storageSession
     )
     {
         if (_crashed)
             throw new TimeoutException();
 
-        var result = await _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession, failIfInterrupted);
+        var result = await _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, failIfInterrupted, storageSession);
         AfterPostponeFunctionFlag.Raise();
 
         return result;

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/WatchDogsTests/CrashableFunctionStore.cs
@@ -131,17 +131,18 @@ public class CrashableFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true
     )
     {
         if (_crashed)
             throw new TimeoutException();
 
-        var result = await _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession);
+        var result = await _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession, failIfInterrupted);
         AfterPostponeFunctionFlag.Raise();
 
         return result;
-    } 
+    }
 
     public Task<bool> FailFunction(
         StoredId storedId,

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -137,6 +137,7 @@ internal class InvocationHelper<TParam, TReturn>
                     _replicaId,
                     effects: null,
                     messages: null,
+                    failIfInterrupted: true,
                     storageSession
                 ) ? PersistResultOutcome.Success : PersistResultOutcome.Reschedule;
             case Outcome.Fail:
@@ -508,8 +509,8 @@ internal class InvocationHelper<TParam, TReturn>
             _replicaId,
             effects: null,
             messages: null,
-            storageSession: null,
-            failIfInterrupted: false
+            failIfInterrupted: false,
+            storageSession: null
         );
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -138,7 +138,7 @@ internal class InvocationHelper<TParam, TReturn>
                     effects: null,
                     messages: null,
                     storageSession
-                ) ? PersistResultOutcome.Success : PersistResultOutcome.Success;
+                ) ? PersistResultOutcome.Success : PersistResultOutcome.Reschedule;
             case Outcome.Fail:
                 return await _functionStore.FailFunction(
                     storedId,
@@ -508,7 +508,8 @@ internal class InvocationHelper<TParam, TReturn>
             _replicaId,
             effects: null,
             messages: null,
-            storageSession: null
+            storageSession: null,
+            failIfInterrupted: false
         );
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
@@ -73,8 +73,8 @@ public interface IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true
+        bool failIfInterrupted,
+        IStorageSession? storageSession
     );
     
     Task<bool> FailFunction(

--- a/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/IFunctionStore.cs
@@ -73,7 +73,8 @@ public interface IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true
     );
     
     Task<bool> FailFunction(

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -298,8 +298,8 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         ReplicaId? expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true)
+        bool failIfInterrupted,
+        IStorageSession? storageSession)
     {
         lock (_sync)
         {

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -298,7 +298,8 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         ReplicaId? expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession)
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true)
     {
         lock (_sync)
         {
@@ -306,9 +307,10 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
 
             var state = _states[storedId];
             if (state.Owner != expectedReplica) return false.ToTask();
+            if (failIfInterrupted && state.Interrupted) return false.ToTask();
 
             state.Status = Status.Postponed;
-            state.Expires = state.Interrupted ? 0 : postponeUntil;
+            state.Expires = postponeUntil;
             state.Interrupted = false;
             state.Timestamp = timestamp;
             state.Owner = null;
@@ -358,12 +360,13 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
             var state = _states[storedId];
             if (state.Owner != expectedReplica)
                 return false.ToTask();
+            if (state.Interrupted)
+                return false.ToTask();
 
-            state.Status = state.Interrupted ? Status.Postponed : Status.Suspended;
+            state.Status = Status.Suspended;
             state.Expires = 0;
             state.Timestamp = timestamp;
             state.Owner = null;
-            state.Interrupted = false;
 
             return true.ToTask();
         }

--- a/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
+++ b/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
@@ -118,10 +118,11 @@ public class CrashableFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true
     ) => _crashed
         ? Task.FromException<bool>(new TimeoutException())
-        : _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession); 
+        : _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession, failIfInterrupted);
 
     public Task<bool> FailFunction(
         StoredId storedId,

--- a/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
+++ b/Samples/Sample.ConsoleApp/Utils/CrashableFunctionStore.cs
@@ -118,11 +118,11 @@ public class CrashableFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true
+        bool failIfInterrupted,
+        IStorageSession? storageSession
     ) => _crashed
         ? Task.FromException<bool>(new TimeoutException())
-        : _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, storageSession, failIfInterrupted);
+        : _inner.PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effects, messages, failIfInterrupted, storageSession);
 
     public Task<bool> FailFunction(
         StoredId storedId,

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/StoreTests.cs
@@ -116,12 +116,8 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => EpochIsNotIncrementedOnSuspension(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction()
-        => SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction(FunctionStoreFactory.Create());
-
-    [TestMethod]
-    public override Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch()
-        => FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch(FunctionStoreFactory.Create());
+    public override Task SuspendingInterruptedFunctionReturnsFalse()
+        => SuspendingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task InterruptCountCanBeIncrementedForExecutingFunction()
@@ -176,16 +172,16 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => MultipleFunctionsStatusCanBeFetched(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted()
-        => InterruptedFunctionIsNotPostponedToZeroWhenInterrupted(FunctionStoreFactory.Create());
-    
+    public override Task PostponingInterruptedFunctionReturnsFalse()
+        => PostponingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
+
     [TestMethod]
     public override Task InterruptNothingWorks()
         => InterruptNothingWorks(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction()
-        => InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction(FunctionStoreFactory.Create());
+    public override Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag()
+        => PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag(FunctionStoreFactory.Create());
     
     [TestMethod]
     public override Task FunctionCanBeCreatedWithMessagesAndEffects()

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -509,8 +509,8 @@ public class MariaDbFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true)
+        bool failIfInterrupted,
+        IStorageSession? storageSession)
     {
         byte[]? effectsBytes = null;
         if (storageSession is SnapshotStorageSession session && session.Effects.Count > 0)

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -509,7 +509,8 @@ public class MariaDbFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession)
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true)
     {
         byte[]? effectsBytes = null;
         if (storageSession is SnapshotStorageSession session && session.Effects.Count > 0)
@@ -517,7 +518,7 @@ public class MariaDbFunctionStore : IFunctionStore
 
         await using var conn = await CreateOpenConnection(_connectionString);
         await using var command = _sqlGenerator
-            .PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, effectsBytes)
+            .PostponeFunction(storedId, postponeUntil, timestamp, expectedReplica, failIfInterrupted, effectsBytes)
             .ToSqlCommand(conn);
 
         var affectedRows = await command.ExecuteNonQueryAsync();

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -267,9 +267,7 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponedFunctionSql;
-    private string? _postponedFunctionFailIfInterruptedSql;
     private string? _postponedFunctionWithEffectsSql;
-    private string? _postponedFunctionWithEffectsFailIfInterruptedSql;
     public StoreCommand PostponeFunction(
         StoredId storedId,
         long postponeUntil,
@@ -280,88 +278,53 @@ public class SqlGenerator(string tablePrefix)
     {
         if (effects == null)
         {
-            string sql;
-            if (failIfInterrupted)
-            {
-                _postponedFunctionFailIfInterruptedSql ??= $@"
-                    UPDATE {tablePrefix}
-                    SET status = {(int)Status.Postponed},
-                        expires = ?,
-                        timestamp = ?,
-                        owner = NULL
-                    WHERE
-                        id = ? AND
-                        owner = ? AND
-                        interrupted = 0";
-                sql = _postponedFunctionFailIfInterruptedSql;
-            }
-            else
-            {
-                _postponedFunctionSql ??= $@"
-                    UPDATE {tablePrefix}
-                    SET status = {(int)Status.Postponed},
-                        expires = ?,
-                        timestamp = ?,
-                        owner = NULL,
-                        interrupted = 0
-                    WHERE
-                        id = ? AND
-                        owner = ?";
-                sql = _postponedFunctionSql;
-            }
+            _postponedFunctionSql ??= $@"
+                UPDATE {tablePrefix}
+                SET status = {(int)Status.Postponed},
+                    expires = ?,
+                    timestamp = ?,
+                    owner = NULL,
+                    interrupted = 0
+                WHERE
+                    id = ? AND
+                    owner = ? AND
+                    (? = 0 OR interrupted = 0)";
 
             return StoreCommand.Create(
-                sql,
+                _postponedFunctionSql,
                 values: [
                     postponeUntil,
                     timestamp,
                     storedId.AsGuid.ToString("N"),
                     expectedReplica.AsGuid.ToString("N"),
+                    failIfInterrupted ? 1 : 0,
                 ]
             );
         }
         else
         {
-            string sql;
-            if (failIfInterrupted)
-            {
-                _postponedFunctionWithEffectsFailIfInterruptedSql ??= $@"
-                    UPDATE {tablePrefix}
-                    SET status = {(int)Status.Postponed},
-                        expires = ?,
-                        timestamp = ?,
-                        owner = NULL,
-                        effects = ?
-                    WHERE
-                        id = ? AND
-                        owner = ? AND
-                        interrupted = 0";
-                sql = _postponedFunctionWithEffectsFailIfInterruptedSql;
-            }
-            else
-            {
-                _postponedFunctionWithEffectsSql ??= $@"
-                    UPDATE {tablePrefix}
-                    SET status = {(int)Status.Postponed},
-                        expires = ?,
-                        timestamp = ?,
-                        owner = NULL,
-                        interrupted = 0,
-                        effects = ?
-                    WHERE
-                        id = ? AND
-                        owner = ?";
-                sql = _postponedFunctionWithEffectsSql;
-            }
+            _postponedFunctionWithEffectsSql ??= $@"
+                UPDATE {tablePrefix}
+                SET status = {(int)Status.Postponed},
+                    expires = ?,
+                    timestamp = ?,
+                    owner = NULL,
+                    interrupted = 0,
+                    effects = ?
+                WHERE
+                    id = ? AND
+                    owner = ? AND
+                    (? = 0 OR interrupted = 0)";
 
             return StoreCommand.Create(
-                sql,
+                _postponedFunctionWithEffectsSql,
                 values: [
                     postponeUntil,
                     timestamp,
                     effects,
                     storedId.AsGuid.ToString("N"),
                     expectedReplica.AsGuid.ToString("N"),
+                    failIfInterrupted ? 1 : 0,
                 ]
             );
         }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -267,29 +267,51 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponedFunctionSql;
+    private string? _postponedFunctionFailIfInterruptedSql;
     private string? _postponedFunctionWithEffectsSql;
+    private string? _postponedFunctionWithEffectsFailIfInterruptedSql;
     public StoreCommand PostponeFunction(
         StoredId storedId,
         long postponeUntil,
         long timestamp,
         ReplicaId expectedReplica,
+        bool failIfInterrupted,
         byte[]? effects = null)
     {
         if (effects == null)
         {
-            _postponedFunctionSql ??= $@"
-                UPDATE {tablePrefix}
-                SET status = {(int)Status.Postponed},
-                    expires = CASE WHEN interrupted = 1 THEN 0 ELSE ? END,
-                    timestamp = ?,
-                    owner = NULL,
-                    interrupted = 0
-                WHERE
-                    id = ? AND
-                    owner = ?";
+            string sql;
+            if (failIfInterrupted)
+            {
+                _postponedFunctionFailIfInterruptedSql ??= $@"
+                    UPDATE {tablePrefix}
+                    SET status = {(int)Status.Postponed},
+                        expires = ?,
+                        timestamp = ?,
+                        owner = NULL
+                    WHERE
+                        id = ? AND
+                        owner = ? AND
+                        interrupted = 0";
+                sql = _postponedFunctionFailIfInterruptedSql;
+            }
+            else
+            {
+                _postponedFunctionSql ??= $@"
+                    UPDATE {tablePrefix}
+                    SET status = {(int)Status.Postponed},
+                        expires = ?,
+                        timestamp = ?,
+                        owner = NULL,
+                        interrupted = 0
+                    WHERE
+                        id = ? AND
+                        owner = ?";
+                sql = _postponedFunctionSql;
+            }
 
             return StoreCommand.Create(
-                _postponedFunctionSql,
+                sql,
                 values: [
                     postponeUntil,
                     timestamp,
@@ -300,20 +322,40 @@ public class SqlGenerator(string tablePrefix)
         }
         else
         {
-            _postponedFunctionWithEffectsSql ??= $@"
-                UPDATE {tablePrefix}
-                SET status = {(int)Status.Postponed},
-                    expires = CASE WHEN interrupted = 1 THEN 0 ELSE ? END,
-                    timestamp = ?,
-                    owner = NULL,
-                    interrupted = 0,
-                    effects = ?
-                WHERE
-                    id = ? AND
-                    owner = ?";
+            string sql;
+            if (failIfInterrupted)
+            {
+                _postponedFunctionWithEffectsFailIfInterruptedSql ??= $@"
+                    UPDATE {tablePrefix}
+                    SET status = {(int)Status.Postponed},
+                        expires = ?,
+                        timestamp = ?,
+                        owner = NULL,
+                        effects = ?
+                    WHERE
+                        id = ? AND
+                        owner = ? AND
+                        interrupted = 0";
+                sql = _postponedFunctionWithEffectsFailIfInterruptedSql;
+            }
+            else
+            {
+                _postponedFunctionWithEffectsSql ??= $@"
+                    UPDATE {tablePrefix}
+                    SET status = {(int)Status.Postponed},
+                        expires = ?,
+                        timestamp = ?,
+                        owner = NULL,
+                        interrupted = 0,
+                        effects = ?
+                    WHERE
+                        id = ? AND
+                        owner = ?";
+                sql = _postponedFunctionWithEffectsSql;
+            }
 
             return StoreCommand.Create(
-                _postponedFunctionWithEffectsSql,
+                sql,
                 values: [
                     postponeUntil,
                     timestamp,
@@ -383,12 +425,11 @@ public class SqlGenerator(string tablePrefix)
         {
             _suspendFunctionSql ??= $@"
                 UPDATE {tablePrefix}
-                SET status = CASE WHEN interrupted = 1 THEN {(int)Status.Postponed} ELSE {(int)Status.Suspended} END,
+                SET status = {(int)Status.Suspended},
                     expires = 0,
                     timestamp = ?,
-                    owner = NULL,
-                    interrupted = 0
-                WHERE id = ? AND owner = ?";
+                    owner = NULL
+                WHERE id = ? AND owner = ? AND interrupted = 0";
 
             return StoreCommand.Create(
                 _suspendFunctionSql,
@@ -403,13 +444,12 @@ public class SqlGenerator(string tablePrefix)
         {
             _suspendFunctionWithEffectsSql ??= $@"
                 UPDATE {tablePrefix}
-                SET status = CASE WHEN interrupted = 1 THEN {(int)Status.Postponed} ELSE {(int)Status.Suspended} END,
+                SET status = {(int)Status.Suspended},
                     expires = 0,
                     timestamp = ?,
                     owner = NULL,
-                    interrupted = 0,
                     effects = ?
-                WHERE id = ? AND owner = ?";
+                WHERE id = ? AND owner = ? AND interrupted = 0";
 
             return StoreCommand.Create(
                 _suspendFunctionWithEffectsSql,

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/StoreTests.cs
@@ -119,12 +119,8 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => EpochIsNotIncrementedOnSuspension(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction()
-        => SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction(FunctionStoreFactory.Create());
-
-    [TestMethod]
-    public override Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch()
-        => FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch(FunctionStoreFactory.Create());
+    public override Task SuspendingInterruptedFunctionReturnsFalse()
+        => SuspendingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task InterruptCountCanBeIncrementedForExecutingFunction()
@@ -179,16 +175,16 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => MultipleFunctionsStatusCanBeFetched(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted()
-        => InterruptedFunctionIsNotPostponedToZeroWhenInterrupted(FunctionStoreFactory.Create());
-    
+    public override Task PostponingInterruptedFunctionReturnsFalse()
+        => PostponingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
+
     [TestMethod]
     public override Task InterruptNothingWorks()
         => InterruptNothingWorks(FunctionStoreFactory.Create());
-    
+
     [TestMethod]
-    public override Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction()
-        => InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction(FunctionStoreFactory.Create());
+    public override Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag()
+        => PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag(FunctionStoreFactory.Create());
     
     [TestMethod]
     public override Task FunctionCanBeCreatedWithMessagesAndEffects()

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
@@ -505,14 +505,16 @@ public class PostgreSqlFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession)
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true)
     {
         await using var conn = await CreateConnection();
         await using var command = _sqlGenerator.PostponeFunction(
             storedId,
             postponeUntil,
             timestamp,
-            expectedReplica
+            expectedReplica,
+            failIfInterrupted
         ).ToNpgsqlCommand(conn);
 
         var affectedRows = await command.ExecuteNonQueryAsync();

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
@@ -505,8 +505,8 @@ public class PostgreSqlFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true)
+        bool failIfInterrupted,
+        IStorageSession? storageSession)
     {
         await using var conn = await CreateConnection();
         await using var command = _sqlGenerator.PostponeFunction(

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -260,25 +260,46 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponeFunctionSql;
+    private string? _postponeFunctionFailIfInterruptedSql;
     public StoreCommand PostponeFunction(
         StoredId storedId,
         long postponeUntil,
         long timestamp,
-        ReplicaId expectedReplica)
+        ReplicaId expectedReplica,
+        bool failIfInterrupted)
     {
-        _postponeFunctionSql ??= $@"
-            UPDATE {tablePrefix}
-            SET status = {(int) Status.Postponed},
-                expires = CASE WHEN interrupted THEN 0 ELSE $1 END,
-                owner = NULL,
-                interrupted = FALSE,
-                timestamp = $4
-            WHERE
-                id = $2 AND
-                owner = $3;";
+        string sql;
+        if (failIfInterrupted)
+        {
+            _postponeFunctionFailIfInterruptedSql ??= $@"
+                UPDATE {tablePrefix}
+                SET status = {(int) Status.Postponed},
+                    expires = $1,
+                    owner = NULL,
+                    timestamp = $4
+                WHERE
+                    id = $2 AND
+                    owner = $3 AND
+                    interrupted = FALSE;";
+            sql = _postponeFunctionFailIfInterruptedSql;
+        }
+        else
+        {
+            _postponeFunctionSql ??= $@"
+                UPDATE {tablePrefix}
+                SET status = {(int) Status.Postponed},
+                    expires = $1,
+                    owner = NULL,
+                    interrupted = FALSE,
+                    timestamp = $4
+                WHERE
+                    id = $2 AND
+                    owner = $3;";
+            sql = _postponeFunctionSql;
+        }
 
         return StoreCommand.Create(
-            _postponeFunctionSql,
+            sql,
             values: [
                 postponeUntil,
                 storedId.AsGuid,
@@ -317,12 +338,11 @@ public class SqlGenerator(string tablePrefix)
     {
         _suspendFunctionSql ??= $@"
             UPDATE {tablePrefix}
-            SET status = CASE WHEN interrupted THEN {(int) Status.Postponed} ELSE {(int) Status.Suspended} END,
+            SET status = {(int) Status.Suspended},
                 expires = 0,
                 owner = NULL,
-                interrupted = FALSE,
                 timestamp = $3
-            WHERE id = $1 AND owner = $2;";
+            WHERE id = $1 AND owner = $2 AND interrupted = FALSE;";
 
         return StoreCommand.Create(
             _suspendFunctionSql,

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -260,7 +260,6 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponeFunctionSql;
-    private string? _postponeFunctionFailIfInterruptedSql;
     public StoreCommand PostponeFunction(
         StoredId storedId,
         long postponeUntil,
@@ -268,43 +267,26 @@ public class SqlGenerator(string tablePrefix)
         ReplicaId expectedReplica,
         bool failIfInterrupted)
     {
-        string sql;
-        if (failIfInterrupted)
-        {
-            _postponeFunctionFailIfInterruptedSql ??= $@"
-                UPDATE {tablePrefix}
-                SET status = {(int) Status.Postponed},
-                    expires = $1,
-                    owner = NULL,
-                    timestamp = $4
-                WHERE
-                    id = $2 AND
-                    owner = $3 AND
-                    interrupted = FALSE;";
-            sql = _postponeFunctionFailIfInterruptedSql;
-        }
-        else
-        {
-            _postponeFunctionSql ??= $@"
-                UPDATE {tablePrefix}
-                SET status = {(int) Status.Postponed},
-                    expires = $1,
-                    owner = NULL,
-                    interrupted = FALSE,
-                    timestamp = $4
-                WHERE
-                    id = $2 AND
-                    owner = $3;";
-            sql = _postponeFunctionSql;
-        }
+        _postponeFunctionSql ??= $@"
+            UPDATE {tablePrefix}
+            SET status = {(int) Status.Postponed},
+                expires = $1,
+                owner = NULL,
+                interrupted = FALSE,
+                timestamp = $4
+            WHERE
+                id = $2 AND
+                owner = $3 AND
+                (NOT $5 OR interrupted = FALSE);";
 
         return StoreCommand.Create(
-            sql,
+            _postponeFunctionSql,
             values: [
                 postponeUntil,
                 storedId.AsGuid,
                 expectedReplica.AsGuid,
                 timestamp,
+                failIfInterrupted,
             ]
         );
     }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/StoreTests.cs
@@ -119,12 +119,8 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => EpochIsNotIncrementedOnSuspension(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction()
-        => SuspensionDoesNotSucceedOnExpectedMessagesCountMismatchButPostponesFunction(FunctionStoreFactory.Create());
-
-    [TestMethod]
-    public override Task FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch()
-        => FunctionIsStillExecutingOnSuspensionAndInterruptCountMismatch(FunctionStoreFactory.Create());
+    public override Task SuspendingInterruptedFunctionReturnsFalse()
+        => SuspendingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task InterruptCountCanBeIncrementedForExecutingFunction()
@@ -179,16 +175,16 @@ public class StoreTests : ResilientFunctions.Tests.TestTemplates.StoreTests
         => MultipleFunctionsStatusCanBeFetched(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task InterruptedFunctionIsNotPostponedToZeroWhenInterrupted()
-        => InterruptedFunctionIsNotPostponedToZeroWhenInterrupted(FunctionStoreFactory.Create());
-    
+    public override Task PostponingInterruptedFunctionReturnsFalse()
+        => PostponingInterruptedFunctionReturnsFalse(FunctionStoreFactory.Create());
+
     [TestMethod]
     public override Task InterruptNothingWorks()
         => InterruptNothingWorks(FunctionStoreFactory.Create());
-    
+
     [TestMethod]
-    public override Task InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction()
-        => InterruptedFunctionIsPostponedWhenIgnoringInterruptedFunction(FunctionStoreFactory.Create());
+    public override Task PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag()
+        => PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag(FunctionStoreFactory.Create());
 
     [TestMethod]
     public override Task FunctionCanBeCreatedWithMessagesAndEffects()

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -268,82 +268,48 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponedFunctionSql;
-    private string? _postponedFunctionFailIfInterruptedSql;
     private string? _postponedFunctionWithEffectsSql;
-    private string? _postponedFunctionWithEffectsFailIfInterruptedSql;
     public StoreCommand PostponeFunction(StoredId storedId, long postponeUntil, long timestamp, ReplicaId expectedReplica, string paramPrefix, bool failIfInterrupted, byte[]? effects = null)
     {
         if (effects == null)
         {
-            string templateSql;
-            if (failIfInterrupted)
-            {
-                _postponedFunctionFailIfInterruptedSql ??= @$"
-                    UPDATE {tablePrefix}
-                    SET Status = {(int)Status.Postponed},
-                        Expires = @PostponedUntil,
-                        Timestamp = @Timestamp,
-                        Owner = NULL
-                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
-                templateSql = _postponedFunctionFailIfInterruptedSql;
-            }
-            else
-            {
-                _postponedFunctionSql ??= @$"
-                    UPDATE {tablePrefix}
-                    SET Status = {(int)Status.Postponed},
-                        Expires = @PostponedUntil,
-                        Timestamp = @Timestamp,
-                        Owner = NULL,
-                        Interrupted = 0
-                    WHERE Id = @Id AND Owner = @ExpectedReplica";
-                templateSql = _postponedFunctionSql;
-            }
+            _postponedFunctionSql ??= @$"
+                UPDATE {tablePrefix}
+                SET Status = {(int)Status.Postponed},
+                    Expires = @PostponedUntil,
+                    Timestamp = @Timestamp,
+                    Owner = NULL,
+                    Interrupted = 0
+                WHERE Id = @Id AND Owner = @ExpectedReplica AND (@FailIfInterrupted = 0 OR Interrupted = 0)";
 
             var sql = paramPrefix == ""
-                ? templateSql
-                : templateSql.Replace("@", $"@{paramPrefix}");
+                ? _postponedFunctionSql
+                : _postponedFunctionSql.Replace("@", $"@{paramPrefix}");
 
             var command = StoreCommand.Create(sql);
             command.AddParameter($"@{paramPrefix}PostponedUntil", postponeUntil);
             command.AddParameter($"@{paramPrefix}Timestamp", timestamp);
             command.AddParameter($"@{paramPrefix}Id", storedId.AsGuid);
             command.AddParameter($"@{paramPrefix}ExpectedReplica", expectedReplica.AsGuid);
+            command.AddParameter($"@{paramPrefix}FailIfInterrupted", failIfInterrupted);
 
             return command;
         }
         else
         {
-            string templateSql;
-            if (failIfInterrupted)
-            {
-                _postponedFunctionWithEffectsFailIfInterruptedSql ??= @$"
-                    UPDATE {tablePrefix}
-                    SET Status = {(int)Status.Postponed},
-                        Expires = @PostponedUntil,
-                        Timestamp = @Timestamp,
-                        Owner = NULL,
-                        Effects = @Effects
-                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
-                templateSql = _postponedFunctionWithEffectsFailIfInterruptedSql;
-            }
-            else
-            {
-                _postponedFunctionWithEffectsSql ??= @$"
-                    UPDATE {tablePrefix}
-                    SET Status = {(int)Status.Postponed},
-                        Expires = @PostponedUntil,
-                        Timestamp = @Timestamp,
-                        Owner = NULL,
-                        Interrupted = 0,
-                        Effects = @Effects
-                    WHERE Id = @Id AND Owner = @ExpectedReplica";
-                templateSql = _postponedFunctionWithEffectsSql;
-            }
+            _postponedFunctionWithEffectsSql ??= @$"
+                UPDATE {tablePrefix}
+                SET Status = {(int)Status.Postponed},
+                    Expires = @PostponedUntil,
+                    Timestamp = @Timestamp,
+                    Owner = NULL,
+                    Interrupted = 0,
+                    Effects = @Effects
+                WHERE Id = @Id AND Owner = @ExpectedReplica AND (@FailIfInterrupted = 0 OR Interrupted = 0)";
 
             var sql = paramPrefix == ""
-                ? templateSql
-                : templateSql.Replace("@", $"@{paramPrefix}");
+                ? _postponedFunctionWithEffectsSql
+                : _postponedFunctionWithEffectsSql.Replace("@", $"@{paramPrefix}");
 
             var command = StoreCommand.Create(sql);
             command.AddParameter($"@{paramPrefix}PostponedUntil", postponeUntil);
@@ -351,6 +317,7 @@ public class SqlGenerator(string tablePrefix)
             command.AddParameter($"@{paramPrefix}Effects", effects);
             command.AddParameter($"@{paramPrefix}Id", storedId.AsGuid);
             command.AddParameter($"@{paramPrefix}ExpectedReplica", expectedReplica.AsGuid);
+            command.AddParameter($"@{paramPrefix}FailIfInterrupted", failIfInterrupted);
 
             return command;
         }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -268,23 +268,41 @@ public class SqlGenerator(string tablePrefix)
     }
     
     private string? _postponedFunctionSql;
+    private string? _postponedFunctionFailIfInterruptedSql;
     private string? _postponedFunctionWithEffectsSql;
-    public StoreCommand PostponeFunction(StoredId storedId, long postponeUntil, long timestamp, ReplicaId expectedReplica, string paramPrefix, byte[]? effects = null)
+    private string? _postponedFunctionWithEffectsFailIfInterruptedSql;
+    public StoreCommand PostponeFunction(StoredId storedId, long postponeUntil, long timestamp, ReplicaId expectedReplica, string paramPrefix, bool failIfInterrupted, byte[]? effects = null)
     {
         if (effects == null)
         {
-            _postponedFunctionSql ??= @$"
-                UPDATE {tablePrefix}
-                SET Status = {(int)Status.Postponed},
-                    Expires = CASE WHEN Interrupted = 1 THEN 0 ELSE @PostponedUntil END,
-                    Timestamp = @Timestamp,
-                    Owner = NULL,
-                    Interrupted = 0
-                WHERE Id = @Id AND Owner = @ExpectedReplica";
+            string templateSql;
+            if (failIfInterrupted)
+            {
+                _postponedFunctionFailIfInterruptedSql ??= @$"
+                    UPDATE {tablePrefix}
+                    SET Status = {(int)Status.Postponed},
+                        Expires = @PostponedUntil,
+                        Timestamp = @Timestamp,
+                        Owner = NULL
+                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
+                templateSql = _postponedFunctionFailIfInterruptedSql;
+            }
+            else
+            {
+                _postponedFunctionSql ??= @$"
+                    UPDATE {tablePrefix}
+                    SET Status = {(int)Status.Postponed},
+                        Expires = @PostponedUntil,
+                        Timestamp = @Timestamp,
+                        Owner = NULL,
+                        Interrupted = 0
+                    WHERE Id = @Id AND Owner = @ExpectedReplica";
+                templateSql = _postponedFunctionSql;
+            }
 
             var sql = paramPrefix == ""
-                ? _postponedFunctionSql
-                : _postponedFunctionSql.Replace("@", $"@{paramPrefix}");
+                ? templateSql
+                : templateSql.Replace("@", $"@{paramPrefix}");
 
             var command = StoreCommand.Create(sql);
             command.AddParameter($"@{paramPrefix}PostponedUntil", postponeUntil);
@@ -296,19 +314,36 @@ public class SqlGenerator(string tablePrefix)
         }
         else
         {
-            _postponedFunctionWithEffectsSql ??= @$"
-                UPDATE {tablePrefix}
-                SET Status = {(int)Status.Postponed},
-                    Expires = CASE WHEN Interrupted = 1 THEN 0 ELSE @PostponedUntil END,
-                    Timestamp = @Timestamp,
-                    Owner = NULL,
-                    Interrupted = 0,
-                    Effects = @Effects
-                WHERE Id = @Id AND Owner = @ExpectedReplica";
+            string templateSql;
+            if (failIfInterrupted)
+            {
+                _postponedFunctionWithEffectsFailIfInterruptedSql ??= @$"
+                    UPDATE {tablePrefix}
+                    SET Status = {(int)Status.Postponed},
+                        Expires = @PostponedUntil,
+                        Timestamp = @Timestamp,
+                        Owner = NULL,
+                        Effects = @Effects
+                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
+                templateSql = _postponedFunctionWithEffectsFailIfInterruptedSql;
+            }
+            else
+            {
+                _postponedFunctionWithEffectsSql ??= @$"
+                    UPDATE {tablePrefix}
+                    SET Status = {(int)Status.Postponed},
+                        Expires = @PostponedUntil,
+                        Timestamp = @Timestamp,
+                        Owner = NULL,
+                        Interrupted = 0,
+                        Effects = @Effects
+                    WHERE Id = @Id AND Owner = @ExpectedReplica";
+                templateSql = _postponedFunctionWithEffectsSql;
+            }
 
             var sql = paramPrefix == ""
-                ? _postponedFunctionWithEffectsSql
-                : _postponedFunctionWithEffectsSql.Replace("@", $"@{paramPrefix}");
+                ? templateSql
+                : templateSql.Replace("@", $"@{paramPrefix}");
 
             var command = StoreCommand.Create(sql);
             command.AddParameter($"@{paramPrefix}PostponedUntil", postponeUntil);
@@ -380,12 +415,11 @@ public class SqlGenerator(string tablePrefix)
         {
             _suspendFunctionSql ??= @$"
                     UPDATE {tablePrefix}
-                    SET Status = CASE WHEN Interrupted = 1 THEN {(int)Status.Postponed} ELSE {(int)Status.Suspended} END,
+                    SET Status = {(int)Status.Suspended},
                         Expires = 0,
                         Timestamp = @Timestamp,
-                        Owner = NULL,
-                        Interrupted = 0
-                    WHERE Id = @Id AND Owner = @ExpectedReplica";
+                        Owner = NULL
+                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
 
             var sql = paramPrefix == ""
                 ? _suspendFunctionSql
@@ -402,13 +436,12 @@ public class SqlGenerator(string tablePrefix)
         {
             _suspendFunctionWithEffectsSql ??= @$"
                     UPDATE {tablePrefix}
-                    SET Status = CASE WHEN Interrupted = 1 THEN {(int)Status.Postponed} ELSE {(int)Status.Suspended} END,
+                    SET Status = {(int)Status.Suspended},
                         Expires = 0,
                         Timestamp = @Timestamp,
                         Owner = NULL,
-                        Interrupted = 0,
                         Effects = @Effects
-                    WHERE Id = @Id AND Owner = @ExpectedReplica";
+                    WHERE Id = @Id AND Owner = @ExpectedReplica AND Interrupted = 0";
 
             var sql = paramPrefix == ""
                 ? _suspendFunctionWithEffectsSql

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
@@ -568,7 +568,8 @@ public class SqlServerFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession)
+        IStorageSession? storageSession,
+        bool failIfInterrupted = true)
     {
         byte[]? effectsBytes = null;
         if (storageSession is SnapshotStorageSession session && session.Effects.Count > 0)
@@ -581,6 +582,7 @@ public class SqlServerFunctionStore : IFunctionStore
             timestamp,
             expectedReplica,
             paramPrefix: "",
+            failIfInterrupted: failIfInterrupted,
             effects: effectsBytes
         ).ToSqlCommand(conn);
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
@@ -568,8 +568,8 @@ public class SqlServerFunctionStore : IFunctionStore
         ReplicaId expectedReplica,
         IReadOnlyList<StoredEffect>? effects,
         IReadOnlyList<StoredMessage>? messages,
-        IStorageSession? storageSession,
-        bool failIfInterrupted = true)
+        bool failIfInterrupted,
+        IStorageSession? storageSession)
     {
         byte[]? effectsBytes = null;
         if (storageSession is SnapshotStorageSession session && session.Effects.Count > 0)

--- a/Stores/StressTests/StressTests/PostponedTest.cs
+++ b/Stores/StressTests/StressTests/PostponedTest.cs
@@ -44,6 +44,7 @@ public static class PostponedTest
                 expectedReplica: ReplicaId.Empty,
                 effects: null,
                 messages: null,
+                failIfInterrupted: true,
                 storageSession: null
             );
         }


### PR DESCRIPTION
## Summary

Previously, `SuspendFunction` and `PostponeFunction` silently absorbed the interrupted flag at the storage layer — they converted the requested state into `Postponed(expires=0)` and cleared the flag, returning `true`. The runtime never saw that an interrupt had been observed, so an interrupt arriving mid-execution was effectively invisible to the caller.

Now both methods return `false` when the row is currently interrupted, letting the caller treat the interrupt as a real signal.

## Changes

- **`SuspendFunction`**: SQL/WHERE now gated on `interrupted = FALSE`; returns false if the row is interrupted. Status stays `Executing`, flag stays set.
- **`PostponeFunction`**: same guard, but gated on a new `failIfInterrupted: bool = true` parameter so the runtime's internal `Reschedule` path can opt out (`failIfInterrupted: false`) and queue the function for immediate re-pickup while consuming the interrupt.
- **`InvocationHelper.PersistResult`** Postpone case now returns `Reschedule` on false (was: `Success` on both branches, which swallowed the failure).
- **`InvocationHelper.Reschedule`** passes `failIfInterrupted: false` since it's the consumer of the interrupt signal.

Applied uniformly across InMemory, PostgreSQL, MariaDB, and SqlServer stores.

## Tests

Replaced 4 obsolete tests that pinned the old silent-convert behaviour with 3 new contract tests, wired into all 4 stores:
- `SuspendingInterruptedFunctionReturnsFalse`
- `PostponingInterruptedFunctionReturnsFalse`
- `PostponingInterruptedFunctionWithFailIfInterruptedFalseSucceedsAndClearsFlag`

## Test plan
- [x] Build solution
- [x] InMemory tests: 520 passed
- [x] PostgreSQL tests: 376 passed
- [x] MariaDB tests: 376 passed
- [x] SqlServer tests: 376 passed