### PR TITLE
Replay pending deletions on QueueManager.Initialize

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -83,19 +83,11 @@ internal class QueueManager : IDisposable
 
             _idempotencyKeys.Initialize();
 
-            var children = _effect.GetChildren(DeliveredPositionsId);
-            var positions = new List<long>();
-            foreach (var childId in children)
-            {
-                var position = _effect.Get<long>(childId);
-                positions.Add(position);
-            }
-
-            if (positions.Any())
+            if (_effect.TryGet<List<long>>(DeliveredPositionsId, out var positions) && positions is { Count: > 0 })
             {
                 await _messageStore.DeleteMessages(_storedId, positions);
-                foreach (var childId in children)
-                    await _effect.Clear(childId, flush: false);
+                positions.Clear();
+                _effect.FlushlessUpsert(DeliveredPositionsId, positions, alias: null);
             }
 
             _initialized = true;


### PR DESCRIPTION
## Summary
- `DeliveredPositionsId` was migrated in d8fefadb from a parent-with-children layout to a single `List<long>` value, but `QueueManager.Initialize` still scanned for children — which no writer produces anymore.
- Restarted flows therefore never replayed pending message deletions: messages already captured into delivery effects could remain in the message store indefinitely.
- Read the persisted `List<long>` directly, matching the `AfterFlush` write pattern (delete from store, clear in place, flushless-upsert empty list).

## Test plan
- [x] `dotnet build` core project
- [x] In-memory messaging test suite (56/56 pass)
- [ ] Store-backed messaging suites (Postgres / SQL Server / MariaDB) on CI