### PR TITLE
PostgreSQL: bulk AppendMessages in a single round-trip

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
@@ -1021,8 +1021,8 @@ public abstract class EffectTests
 
         for (var i = 0; i < 6; i++)
         {
-            await BusyWait.Until(() => flag.Value == i);
-            await cp.BusyWaitUntil(c => c.Status == Status.Suspended);
+            await BusyWait.Until(() => flag.Value == i, maxWait: TimeSpan.FromSeconds(30));
+            await cp.BusyWaitUntil(c => c.Status == Status.Suspended, maxWait: TimeSpan.FromSeconds(30));
             var storedEffects = await effectStore.GetEffectResults(registration.MapToStoredId(id.Instance));
             storedEffects.Any(e => e.Alias == "Before").ShouldBeTrue();
             storedEffects.Any(e => e.Alias == "Loop").ShouldBeTrue();
@@ -1032,7 +1032,7 @@ public abstract class EffectTests
             await messageWriter.AppendMessage(i.ToString());
         }
 
-        await cp.BusyWaitUntil(c => c.Status == Status.Succeeded);
+        await cp.BusyWaitUntil(c => c.Status == Status.Succeeded, maxWait: TimeSpan.FromSeconds(30));
 
         iterations.SequenceEqual([0, 1, 2, 3, 4, 5]).ShouldBeTrue();
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Helpers;
@@ -60,62 +59,25 @@ public class PostgreSqlMessageStore : IMessageStore
     public async Task AppendMessage(StoredId storedId, StoredMessage storedMessage)
         => await messageBatcher.Handle(storedId, [storedMessage]);
 
-    private string? _appendMessagesSql;
-    private async Task AppendMessages(StoredId storedId, IReadOnlyList<StoredMessage> messages)
+    private Task AppendMessages(StoredId storedId, IReadOnlyList<StoredMessage> messages)
+        => AppendMessages(messages.Select(m => new StoredIdAndMessage(storedId, m)).ToList());
+
+    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         if (messages.Count == 0)
             return;
 
-        var randomOffset = Random.Shared.Next();
-
-        _appendMessagesSql ??= @$"
-            WITH max_pos AS (
-                SELECT COALESCE(MAX(position), -1) + 2147483647 + $2 AS pos
-                FROM {tablePrefix}_messages
-                WHERE id = $1
-            )
-            INSERT INTO {tablePrefix}_messages (id, position, content)
-            SELECT $1, (SELECT pos FROM max_pos) + ord, content
-            FROM unnest($3::bytea[]) WITH ORDINALITY AS t(content, ord);";
-
-        var contents = new byte[messages.Count][];
-        for (var i = 0; i < messages.Count; i++)
-        {
-            var (messageContent, messageType, _, idempotencyKey, sender, receiver) = messages[i];
-            contents[i] = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
-        }
-
-        var appendBatchCommand = new NpgsqlBatchCommand(_appendMessagesSql);
-        appendBatchCommand.Parameters.Add(new() { Value = storedId.AsGuid });
-        appendBatchCommand.Parameters.Add(new() { Value = (long)randomOffset });
-        appendBatchCommand.Parameters.Add(new() { Value = contents });
-
-        var interruptCommand = sqlGenerator.Interrupt([storedId]);
+        var commands = messages
+            .GroupBy(m => m.StoredId)
+            .Select(g => sqlGenerator.AppendMessages(g.Key, g.Select(m => m.StoredMessage)))
+            .Append(sqlGenerator.Interrupt(messages.Select(m => m.StoredId).Distinct()));
 
         await using var conn = await CreateConnection();
-        await using var batch = new NpgsqlBatch(conn);
-        batch.BatchCommands.Add(appendBatchCommand);
-        batch.BatchCommands.Add(interruptCommand.ToNpgsqlBatchCommand());
+        await using var batch = commands
+            .ToNpgsqlBatch()
+            .WithConnection(conn);
 
         await batch.ExecuteNonQueryAsync();
-    }
-
-    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
-    {
-        var maxPositions = await GetMaxPositions(
-            storedIds: messages.Select(msg => msg.StoredId).Distinct().ToList()
-        );
-
-        var messageWithPositions = messages
-            .Select(msg =>
-                new StoredIdAndMessageWithPosition(
-                    msg.StoredId,
-                    msg.StoredMessage,
-                    ++maxPositions[msg.StoredId]
-                )
-            ).ToList();
-
-        await AppendMessages(messageWithPositions);
     }
 
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -452,6 +452,44 @@ public class SqlGenerator(string tablePrefix)
         return null;
     } 
 
+    private string? _appendMessagesSql;
+    public StoreCommand AppendMessages(StoredId storedId, IEnumerable<StoredMessage> messages)
+    {
+        // Computes per-message positions server-side so the SQL string is constant regardless of batch size.
+        // max_pos: base = COALESCE(MAX(position), -1) + 2147483647 + $2 (random) — placed well above any
+        // existing position and randomized per call so concurrent appenders to the same flow rarely collide.
+        // unnest($3::bytea[]) WITH ORDINALITY expands the byte[][] parameter into rows with a 1-based offset,
+        // so each inserted row gets a unique position = base + pos_offset, in caller order.
+        _appendMessagesSql ??= @$"
+            WITH max_pos AS (
+                SELECT COALESCE(MAX(position), -1) + 2147483647 + $2 AS pos
+                FROM {tablePrefix}_messages
+                WHERE id = $1
+            )
+            INSERT INTO {tablePrefix}_messages (id, position, content)
+            SELECT $1, (SELECT pos FROM max_pos) + pos_offset, content
+            FROM unnest($3::bytea[]) WITH ORDINALITY AS t(content, pos_offset);";
+
+        var contents = messages
+            .Select(m => BinaryPacker.Pack(
+                m.MessageContent,
+                m.MessageType,
+                m.IdempotencyKey?.ToUtf8Bytes(),
+                m.Sender?.ToUtf8Bytes(),
+                m.Receiver?.ToUtf8Bytes()
+            ))
+            .ToArray();
+
+        return StoreCommand.Create(
+            _appendMessagesSql,
+            values: [
+                storedId.AsGuid,
+                (long)Random.Shared.Next(),
+                contents
+            ]
+        );
+    }
+
     public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
     {
         var sql = @$"    


### PR DESCRIPTION
## Summary
- Move the per-flow `AppendMessages` SQL into `SqlGenerator` so all message-store SQL lives in one place, alongside the existing position-explicit `AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition>)` overload.
- Rewrite `PostgreSqlMessageStore.AppendMessages(IReadOnlyList<StoredIdAndMessage>)` to group by `StoredId`, build one per-flow append command via `SqlGenerator`, and execute together with the interrupt in a single `NpgsqlBatch`. This drops the separate `GetMaxPositions` round-trip.
- Single-flow `AppendMessages(StoredId, IReadOnlyList<StoredMessage>)` is now a thin wrapper around the bulk overload.

The append SQL itself is parameterized via `unnest(\$3::bytea[]) WITH ORDINALITY`, so the SQL string is constant regardless of batch size and PostgreSQL's prepared-statement cache is reused across calls. The per-call random base offset (`COALESCE(MAX(position), -1) + 2147483647 + \$2`) preserves the existing collision-avoidance scheme for concurrent appenders to the same flow.

## Test plan
- [x] `dotnet test ./Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests --filter "FullyQualifiedName~Messaging|FullyQualifiedName~WorkflowMessageTests"` — 73/73 passing