### PR TITLE
Effect: hold FlowState directly instead of FlowsManager + StoredId

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
@@ -332,7 +332,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
 
         effect.TryGet<int>("alias", out _).ShouldBeFalse();
 
@@ -380,7 +380,7 @@ public abstract class EffectTests
             storageSession: null,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
 
         // Verify the effect is immediately available (eager loading)
         effect.TryGet<int>("test_alias", out var result).ShouldBeTrue();
@@ -714,7 +714,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
 
         var result = await effect.Capture(() => "hello world", ResiliencyLevel.AtLeastOnceDelayFlush);
         result.ShouldBe("hello world");

--- a/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
@@ -43,7 +43,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1]\n";
@@ -75,7 +75,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1] my-effect\n";
@@ -111,7 +111,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✗ [1] failed-operation (System.InvalidOperationException)\n";
@@ -143,7 +143,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ⋯ [1] in-progress\n";
@@ -189,7 +189,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -245,7 +245,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -295,7 +295,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -330,7 +330,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -365,7 +365,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -398,7 +398,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowsManager(), storedId);
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
         var output = effect.ExecutionTree();
 
         var expected =

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -38,17 +38,4 @@ public class FlowsManager
                     flowState.Interrupt();
     }
 
-    public void StartThread(StoredId id)
-    {
-        lock (_lock)
-            if (_dict.TryGetValue(id, out var flowState))
-                flowState.SubflowStarted();
-    }
-
-    public void CompleteThread(StoredId id)
-    {
-        lock (_lock)
-            if (_dict.TryGetValue(id, out var flowState))
-                flowState.SubflowCompleted();
-    }
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -385,7 +385,7 @@ internal class InvocationHelper<TParam, TReturn>
     public MessageWriter CreateMessageWriter(StoredId storedId)
         => new MessageWriter(storedId, _functionStore.MessageStore, Serializer);
 
-    public Effect CreateEffect(StoredId storedId, FlowId flowId, IReadOnlyList<StoredEffect> storedEffects, FlowTimeouts flowTimeouts, IStorageSession? storageSession, FlowsManager flowsManager)
+    public Effect CreateEffect(StoredId storedId, FlowId flowId, IReadOnlyList<StoredEffect> storedEffects, FlowTimeouts flowTimeouts, IStorageSession? storageSession, FlowState flowState)
     {
         var effectsStore = _functionStore.EffectsStore;
 
@@ -399,7 +399,7 @@ internal class InvocationHelper<TParam, TReturn>
             _clearChildren
         );
 
-       var effect = new Effect(effectResults, UtcNow, flowTimeouts, flowsManager, storedId);
+       var effect = new Effect(effectResults, UtcNow, flowTimeouts, flowState);
        return effect;
     }
 

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -270,6 +270,7 @@ public class Invoker<TParam, TReturn>
                 );
 
             var flowTimeouts = new FlowTimeouts();
+            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
 
             var effect = _invocationHelper.CreateEffect(
                 storedId,
@@ -277,10 +278,9 @@ public class Invoker<TParam, TReturn>
                 initialState == null ? [] : _invocationHelper.MapInitialEffects(initialState.Effects, flowId),
                 flowTimeouts,
                 storageSession,
-                _flowsManager
+                flowState
             );
 
-            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
             var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);
@@ -328,10 +328,10 @@ public class Invoker<TParam, TReturn>
             disposables.Add(isWorkflowRunningDisposable);
             
             var flowTimeouts = new FlowTimeouts();
-
-            var effect = _invocationHelper.CreateEffect(storedId, flowId, effects, flowTimeouts, storageSession, _flowsManager);
-
             var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
+
+            var effect = _invocationHelper.CreateEffect(storedId, flowId, effects, flowTimeouts, storageSession, flowState);
+
             var queueManager = _invocationHelper.CreateQueueManager(flowId, storedId, effect, flowState, flowTimeouts, _unhandledExceptionHandler);
             disposables.Add(queueManager);
             var messageWriter = _invocationHelper.CreateMessageWriter(storedId);

--- a/Core/Cleipnir.ResilientFunctions/Domain/Effect.cs
+++ b/Core/Cleipnir.ResilientFunctions/Domain/Effect.cs
@@ -21,16 +21,14 @@ public class Effect
     private readonly EffectResults effectResults;
     private readonly UtcNow utcNow;
     private readonly FlowTimeouts flowTimeouts;
-    private readonly FlowsManager flowsManager;
-    private readonly StoredId storedId;
+    private readonly FlowState flowState;
 
-    internal Effect(EffectResults effectResults, UtcNow utcNow, FlowTimeouts flowTimeouts, FlowsManager flowsManager, StoredId storedId)
+    internal Effect(EffectResults effectResults, UtcNow utcNow, FlowTimeouts flowTimeouts, FlowState flowState)
     {
         this.effectResults = effectResults;
         this.utcNow = utcNow;
         this.flowTimeouts = flowTimeouts;
-        this.flowsManager = flowsManager;
-        this.storedId = storedId;
+        this.flowState = flowState;
     }
 
 
@@ -297,11 +295,11 @@ public class Effect
 
     public Task<T> RunParallelle<T>(Func<Task<T>> work)
     {
-        flowsManager.StartThread(storedId);
+        flowState.SubflowStarted();
         var task = Capture(() => Task.Run(work));
         return task.ContinueWith(t =>
         {
-            flowsManager.CompleteThread(storedId);
+            flowState.SubflowCompleted();
             return t.GetAwaiter().GetResult();
         });
     }


### PR DESCRIPTION
## Summary
- `Effect` now stores a `FlowState` reference instead of `FlowsManager` + `StoredId`. `RunParallelle` calls `flowState.SubflowStarted/Completed` directly, skipping the dictionary lookup + lock that `FlowsManager.StartThread/CompleteThread` did on every call.
- Removed the now-unused `FlowsManager.StartThread` / `FlowsManager.CompleteThread`.
- Reordered `Invoker.PrepareForInvocation` / `PrepareForReInvocation` so `_flowsManager.CreateFlow(...)` runs before `CreateEffect(...)`, since `Effect` now requires the `FlowState` at construction time.

## Test plan
- [x] `dotnet build Cleipnir.ResilientFunctions.sln` clean
- [x] In-memory `EffectTests` and `PrintEffectsTests` (48 tests) pass
- [x] `RunParallelleTest` passes
- [ ] Full DB-backed test suites (PostgreSQL / SqlServer / MariaDB) — touched code paths are runtime-engine only, not store-specific, but worth a CI confirmation