### PR TITLE
FlowState: add Status, thread invoker Task, simplify resume/interrupt

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -561,7 +561,7 @@ public abstract class MessagesSubscriptionTests
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager();
-                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts, completed: ForeverTask.Instance);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -624,7 +624,7 @@ public abstract class MessagesSubscriptionTests
                 storedId = workflow.StoredId;
                 var minimumTimeout = new FlowTimeouts();
                 var flowsManager = new FlowsManager();
-                var flowState = flowsManager.CreateFlow(workflow.StoredId, minimumTimeout);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, minimumTimeout, completed: ForeverTask.Instance);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
@@ -685,7 +685,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
 
                 var flowTimeouts = new FlowTimeouts();
                 var flowsManager = new FlowsManager();
-                var flowState = flowsManager.CreateFlow(workflow.StoredId, flowTimeouts);
+                var flowState = flowsManager.CreateFlowState(workflow.StoredId, flowTimeouts, completed: ForeverTask.Instance);
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/EffectTests.cs
@@ -332,7 +332,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
 
         effect.TryGet<int>("alias", out _).ShouldBeFalse();
 
@@ -380,7 +380,7 @@ public abstract class EffectTests
             storageSession: null,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
 
         // Verify the effect is immediately available (eager loading)
         effect.TryGet<int>("test_alias", out var result).ShouldBeTrue();
@@ -714,7 +714,7 @@ public abstract class EffectTests
             session,
             clearChildren: true
         );
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
 
         var result = await effect.Capture(() => "hello world", ResiliencyLevel.AtLeastOnceDelayFlush);
         result.ShouldBe("hello world");

--- a/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/PrintEffectsTests.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
 using Cleipnir.ResilientFunctions.Domain;
+using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Storage;
 using Cleipnir.ResilientFunctions.Tests.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -43,7 +44,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1]\n";
@@ -75,7 +76,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✓ [1] my-effect\n";
@@ -111,7 +112,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ✗ [1] failed-operation (System.InvalidOperationException)\n";
@@ -143,7 +144,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected = "└─ ⋯ [1] in-progress\n";
@@ -189,7 +190,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -245,7 +246,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -295,7 +296,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -330,7 +331,7 @@ public class PrintEffectsTests
             clearChildren: true
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -365,7 +366,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =
@@ -398,7 +399,7 @@ public class PrintEffectsTests
             clearChildren: false
         );
 
-        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts()));
+        var effect = new Effect(effectResults, utcNow: () => DateTime.UtcNow, new FlowTimeouts(), new FlowState(storedId, subflows: 1, waitingSubflows: 0, new FlowTimeouts(), completed: ForeverTask.Instance));
         var output = effect.ExecutionTree();
 
         var expected =

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -1,9 +1,17 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Queuing;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
+
+public enum FlowStatus
+{
+    Running = 0,
+    Waiting = 1,
+    Completed = 2
+}
 
 public class FlowState
 {
@@ -18,17 +26,42 @@ public class FlowState
     public bool Suspended { get; private set; }
     public Task SuspendedTask { get; }
 
+    private FlowStatus _status = FlowStatus.Running;
+    public FlowStatus Status
+    {
+        get
+        {
+            lock (_lock)
+                return _status;
+        }
+        set
+        {
+            lock (_lock)
+                if (_status != FlowStatus.Completed)
+                    _status = value;
+        }
+    }
+
     public FlowState(
         StoredId id,
         int subflows,
         int waitingSubflows,
-        FlowTimeouts timeouts)
+        FlowTimeouts timeouts,
+        Task completed)
     {
         Id = id;
         Subflows = subflows;
         WaitingSubflows = waitingSubflows;
         Timeouts = timeouts;
         SuspendedTask = _suspendedTcs.Task;
+
+        _ = completed.ContinueWith(_ => Status = FlowStatus.Completed);
+    }
+
+    public bool Waiting()
+    {
+        lock (_lock)
+            return Subflows == WaitingSubflows;
     }
 
     public void SubflowStarted()
@@ -49,25 +82,20 @@ public class FlowState
             WaitingSubflows++;
     }
 
-    public bool TryResumeSubflow()
+    public Task ResumeSubflow()
     {
         lock (_lock)
             if (Suspended)
-                return false;
+                return ForeverTask.Instance;
             else
                 WaitingSubflows--;
 
-        return true;
+        return Task.CompletedTask;
     }
 
     public void Interrupt()
     {
-        lock (_lock)
-            if (Suspended)
-                return;
-            else
-                WaitingSubflows = 0;
-
+        if (Suspended) return;
         QueueManager?.Interrupt();
     }
 

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -11,10 +11,10 @@ public class FlowsManager
     private readonly Dictionary<StoredId, FlowState> _dict = new();
     private readonly Lock _lock = new();
 
-    public FlowState CreateFlow(StoredId id, FlowTimeouts timeouts)
+    public FlowState CreateFlowState(StoredId id, FlowTimeouts timeouts, Task completed)
     {
         lock (_lock)
-            return _dict[id] = new FlowState(id, subflows: 1, waitingSubflows: 0, timeouts);
+            return _dict[id] = new FlowState(id, subflows: 1, waitingSubflows: 0, timeouts, completed);
     }
 
     public void RemoveFlow(StoredId id, FlowState flowState)
@@ -37,5 +37,24 @@ public class FlowsManager
                 if (_dict.TryGetValue(id, out var flowState))
                     flowState.Interrupt();
     }
+
+    /*
+    public async Task CheckForSuspension()
+    {
+        while (true)
+        {
+            var waitingFlows = new List<FlowState>();
+            lock (_dict)
+            {
+                waitingFlows = _dict.Values.Where(s => s.)
+                foreach (var flowState in _dict.Values)
+                {
+                    flowState.
+                }
+            }
+            
+            await Task.Delay(250);
+        }
+    }*/
 
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/Invoker.cs
@@ -51,7 +51,8 @@ public class Invoker<TParam, TReturn>
             if (parentWorkflow.Effect.Contains(scheduledAlreadyParentId!))
                 return _invocationHelper.CreateInnerScheduled([flowId], parentWorkflow, detach);
 
-        var (created, workflow, disposables, queueManager, flowState, timeouts, storageSession) = await PrepareForInvocation(flowId, storedId, param, parentWorkflow?.StoredId, initialState);
+        var tcs = new TaskCompletionSource<TReturn>();
+        var (created, workflow, disposables, queueManager, flowState, timeouts, storageSession) = await PrepareForInvocation(flowId, storedId, param, parentWorkflow?.StoredId, initialState, tcs.Task);
         await (parentWorkflow?.Effect.Upsert(scheduledAlreadyParentId!, true, alias: null, flush: false) ?? Task.CompletedTask);
 
         if (!created)
@@ -59,7 +60,6 @@ public class Invoker<TParam, TReturn>
 
         CurrentFlow._workflow.Value = workflow;
 
-        var tcs = new TaskCompletionSource<TReturn>();
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -151,10 +151,10 @@ public class Invoker<TParam, TReturn>
 
     public async Task<InnerScheduled<TReturn>> ScheduleRestart(StoredId storedId)
     {
-        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId);
+        var tcs = new TaskCompletionSource<TReturn>();
+        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId, tcs.Task);
         var flowId = new FlowId(_flowType, humanInstanceId);
 
-        var tcs = new TaskCompletionSource<TReturn>();
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -205,10 +205,10 @@ public class Invoker<TParam, TReturn>
 
     internal async Task ScheduleRestart(StoredId storedId, RestartedFunction rf, Action onCompletion)
     {
-        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId, rf);
+        var tcs = new TaskCompletionSource<TReturn>();
+        var (inner, param, humanInstanceId, workflow, disposables, queueManager, flowState, timeouts, parent, storageSession) = await PrepareForReInvocation(storedId, rf, tcs.Task);
         var flowId = new FlowId(_flowType, humanInstanceId);
 
-        var tcs = new TaskCompletionSource<TReturn>();
         _ = flowState.SuspendedTask.ContinueWith(_ => tcs.TrySetException(new InvocationSuspendedException(flowId)));
         _ = Task.Run(async () =>
         {
@@ -237,7 +237,7 @@ public class Invoker<TParam, TReturn>
         });
     }
     
-    private async Task<PreparedInvocation> PrepareForInvocation(FlowId flowId, StoredId storedId, TParam param, StoredId? parent, InitialState? initialState)
+    private async Task<PreparedInvocation> PrepareForInvocation(FlowId flowId, StoredId storedId, TParam param, StoredId? parent, InitialState? initialState, Task completed)
     {
         var disposables = new List<IDisposable>(capacity: 3);
         var success = false;
@@ -270,7 +270,7 @@ public class Invoker<TParam, TReturn>
                 );
 
             var flowTimeouts = new FlowTimeouts();
-            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
+            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts, completed);
 
             var effect = _invocationHelper.CreateEffect(
                 storedId,
@@ -307,16 +307,16 @@ public class Invoker<TParam, TReturn>
     }
     private record PreparedInvocation(bool Persisted, Workflow Workflow, IDisposable Disposables, QueueManager QueueManager, FlowState FlowState, FlowTimeouts FlowTimeouts, IStorageSession? StorageSession = null);
 
-    private async Task<PreparedReInvocation> PrepareForReInvocation(StoredId storedId)
+    private async Task<PreparedReInvocation> PrepareForReInvocation(StoredId storedId, Task completed)
     {
         var restartedFunction = await _invocationHelper.RestartFunction(storedId);
         if (restartedFunction == null)
             throw UnexpectedStateException.ConcurrentModification(storedId);
 
-        return await PrepareForReInvocation(storedId, restartedFunction);
+        return await PrepareForReInvocation(storedId, restartedFunction, completed);
     }
 
-    private async Task<PreparedReInvocation> PrepareForReInvocation(StoredId storedId, RestartedFunction restartedFunction)
+    private async Task<PreparedReInvocation> PrepareForReInvocation(StoredId storedId, RestartedFunction restartedFunction, Task completed)
     {
         var disposables = new List<IDisposable>(capacity: 3);
         try
@@ -328,7 +328,7 @@ public class Invoker<TParam, TReturn>
             disposables.Add(isWorkflowRunningDisposable);
             
             var flowTimeouts = new FlowTimeouts();
-            var flowState = _flowsManager.CreateFlow(storedId, flowTimeouts);
+            var flowState = _flowsManager.CreateFlowState(storedId, flowTimeouts, completed);
 
             var effect = _invocationHelper.CreateEffect(storedId, flowId, effects, flowTimeouts, storageSession, flowState);
 

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -152,8 +152,7 @@ internal class QueueManager : IDisposable
         }
         finally
         {
-            if (!_flowState.TryResumeSubflow())
-                await ForeverTask.Instance;
+            await _flowState.ResumeSubflow();
 
             await delayCts.CancelAsync();
             delayCts.Dispose();


### PR DESCRIPTION
## Summary

Scaffolding for centralised suspension via `FlowsManager`. No behaviour change yet — nothing calls `FlowState.Suspend()` in this PR.

- `FlowState` constructor now takes a completion `Task` and hooks a `ContinueWith` that flips `Status` to `Completed` when the invoker's `TaskCompletionSource` resolves. Setter guards `Completed` as terminal.
- `Waiting()` returns `Subflows == WaitingSubflows`.
- `TryResumeSubflow()` (returning bool) becomes `ResumeSubflow()` returning `ForeverTask.Instance` when suspended or `Task.CompletedTask` otherwise. Call site in `QueueManager.Subscribe` collapses to a single `await`.
- `Interrupt()` no longer zeros `WaitingSubflows`: that desynchronised the counter — subsequent `ResumeSubflow` calls drove it negative, which silently prevented future `Suspend()` from ever triggering. Now it just delegates to `QueueManager.Interrupt()` when not suspended.
- `Invoker` creates its `TaskCompletionSource` before `PrepareFor[Re]Invocation` and threads `tcs.Task` through `CreateFlowState`, so `FlowState` can observe the invocation's terminal state directly.

Test files that hand-roll `FlowState`/`CreateFlowState` (`PrintEffectsTests`, `EffectTests`, `MessagesSubscriptionTests`) now pass `ForeverTask.Instance` for the completion Task.

## Follow-ups (not in this PR)

- Implement `CheckForSuspension` loop in `FlowsManager` and start it from `FunctionsRegistry`.
- Make `Suspend()` fault live `QueueManager` subscriptions with `SuspendInvocationException` so the user-function task exits and the existing `PersistResult` path runs.
- Decouple `MessagesDefaultMaxWaitForCompletion` from per-subscription auto-suspension in `QueueManager.Subscribe`.

## Test plan

- [x] In-memory suite: 451/451 pass
- [x] PostgreSQL suite: 377/377 pass
- [x] SqlServer / MariaDB: single-test runs pass for the central test paths; full-suite hang on `PingPongMessagesCanBeExchangedMultipleTimes` is pre-existing (reproduced on `main` baseline without this branch)