### PR TITLE
Messages: identity-based position instead of computed per-flow position

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -214,7 +214,8 @@ public abstract class MessageStoreTests
             .ShouldBeAsync(2);
         
         var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "3");
-        await messageStore.ReplaceMessage(functionId, position: 2, storedEvent3).ShouldBeFalseAsync();
+        var nonExistentPosition = (await messageStore.GetMessages(functionId)).Max(m => m.Position) + 1;
+        await messageStore.ReplaceMessage(functionId, nonExistentPosition, storedEvent3).ShouldBeFalseAsync();
         
         var events = (await messageStore.GetMessages(functionId)).ToList();
         events.Count.ShouldBe(2);

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -14,6 +14,7 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
 {
     private readonly Dictionary<StoredId, InnerState> _states = new();
     private readonly Dictionary<StoredId, Dictionary<long, StoredMessage>> _messages = new();
+    private long _nextMessagePosition;
     private readonly Lock _sync = new();
 
     public ITypeStore TypeStore { get; } = new InMemoryTypeStore();
@@ -589,7 +590,7 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
                 _messages[storedId] = new Dictionary<long, StoredMessage>();
 
             var messages = _messages[storedId];
-            messages[messages.Count] = storedMessage;
+            messages[_nextMessagePosition++] = storedMessage;
 
             return Interrupt(storedId);
         }
@@ -606,14 +607,14 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
 
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
     {
-        foreach (var (storedId, storedMessage, position) in messages)
+        foreach (var (storedId, storedMessage, _) in messages)
         {
             lock (_sync)
             {
                 if (!_messages.ContainsKey(storedId))
                     _messages[storedId] = new Dictionary<long, StoredMessage>();
 
-                _messages[storedId].Add(position, storedMessage);
+                _messages[storedId].Add(_nextMessagePosition++, storedMessage);
             }
 
             await Interrupt(storedId);
@@ -624,10 +625,10 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
     {
         lock (_sync)
         {
-            if (!_messages.ContainsKey(storedId) || _messages[storedId].Count <= position)
+            if (!_messages.TryGetValue(storedId, out var messages) || !messages.ContainsKey(position))
                 return false.ToTask();
 
-            _messages[storedId][(int)position] = storedMessage;
+            messages[position] = storedMessage;
             return true.ToTask();
         }
     }
@@ -683,8 +684,11 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
     public Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds)
     {
         IDictionary<StoredId, long> positions = new Dictionary<StoredId, long>();
-        foreach (var storedId in storedIds)
-            positions[storedId] = GetMessagesInternal(storedId).Count() - 1;
+        lock (_sync)
+            foreach (var storedId in storedIds)
+                positions[storedId] = _messages.TryGetValue(storedId, out var messages) && messages.Count > 0
+                    ? messages.Keys.Max()
+                    : -1;
 
         return positions.ToTask();
     }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -28,10 +28,10 @@ public class MariaDbMessageStore : IMessageStore
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         _initializeSql ??= @$"
             CREATE TABLE IF NOT EXISTS {_tablePrefix}_messages (
+                position BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                 id CHAR(32),
-                position BIGINT,
                 content LONGBLOB,
-                PRIMARY KEY (id, position)
+                INDEX {_tablePrefix}_messages_id_idx (id)
             );";
         var command = new MySqlCommand(_initializeSql, conn);
         await command.ExecuteNonQueryAsync();
@@ -55,61 +55,30 @@ public class MariaDbMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        const int maxRetries = 20;
-        const int baseDelayMs = 10;
-        MySqlException? lastException = null;
+        var values = messages.Select(_ => "(?, ?)").StringJoin(", ");
 
-        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        var sql = @$"
+            INSERT INTO {_tablePrefix}_messages
+                (id, content)
+            VALUES
+                {values};";
+
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var command = new MySqlCommand(sql, conn);
+
+        foreach (var (messageContent, messageType, _, idempotencyKey, sender, receiver) in messages)
         {
-            try
-            {
-                var randomOffset = Random.Shared.Next();
-                var values = messages.Select(_ => "(?, @max_pos := @max_pos + 1, ?)").StringJoin(", ");
-
-                var sql = @$"
-                    SET @max_pos = (SELECT COALESCE(MAX(position), -1) FROM {_tablePrefix}_messages WHERE id = ?) + 2147483647 + ?;
-                    INSERT INTO {_tablePrefix}_messages
-                        (id, position, content)
-                    VALUES
-                        {values};";
-
-                await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-                await using var command = new MySqlCommand(sql, conn);
-
-                command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
-                command.Parameters.Add(new() { Value = randomOffset });
-
-                foreach (var (messageContent, messageType, _, idempotencyKey, sender, receiver) in messages)
-                {
-                    command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
-                    var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
-                    command.Parameters.Add(new() { Value = content });
-                }
-
-                await command.ExecuteNonQueryAsync();
-
-                // Execute interrupt command
-                var interruptCommand = _sqlGenerator.Interrupt([storedId]);
-                await using var interruptCmd = interruptCommand.ToSqlCommand(conn);
-                await interruptCmd.ExecuteNonQueryAsync();
-
-                return; // Success - exit retry loop
-            }
-            catch (MySqlException ex) when (ex.ErrorCode == MySqlErrorCode.LockDeadlock && attempt < maxRetries)
-            {
-                lastException = ex;
-                // Deadlock detected - retry with exponential backoff
-                var delayMs = baseDelayMs * (1 << attempt) + Random.Shared.Next(0, baseDelayMs);
-                await Task.Delay(delayMs);
-                // Loop will retry
-            }
+            command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
+            var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
+            command.Parameters.Add(new() { Value = content });
         }
 
-        // All retries exhausted - throw the last exception
-        throw new InvalidOperationException(
-            $"Failed to append message after {maxRetries} retries due to deadlocks",
-            lastException
-        );
+        await command.ExecuteNonQueryAsync();
+
+        // Execute interrupt command
+        var interruptCommand = _sqlGenerator.Interrupt([storedId]);
+        await using var interruptCmd = interruptCommand.ToSqlCommand(conn);
+        await interruptCmd.ExecuteNonQueryAsync();
     }
 
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
@@ -117,51 +86,20 @@ public class MariaDbMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        const int maxRetries = 5;
-        const int baseDelayMs = 10;
-        MySqlException? lastException = null;
+        var storedIds = messages.Select(m => m.StoredId).Distinct().ToList();
+        var messagesWithPosition = messages
+            .Select(msg => new StoredIdAndMessageWithPosition(msg.StoredId, msg.StoredMessage, Position: 0))
+            .ToList();
 
-        for (var attempt = 0; attempt <= maxRetries; attempt++)
-        {
-            try
-            {
-                var storedIds = messages.Select(m => m.StoredId).Distinct().ToList();
-                var maxPositions = await GetMaxPositions(storedIds);
+        var appendMessagesCommand = _sqlGenerator.AppendMessages(messagesWithPosition);
+        var interruptsCommand = _sqlGenerator.Interrupt(storedIds);
 
-                var messagesWithPosition = messages.Select(msg =>
-                    new StoredIdAndMessageWithPosition(
-                        msg.StoredId,
-                        msg.StoredMessage,
-                        ++maxPositions[msg.StoredId]
-                    )
-                ).ToList();
+        var command = StoreCommand.Merge(appendMessagesCommand, interruptsCommand);
 
-                var appendMessagesCommand = _sqlGenerator.AppendMessages(messagesWithPosition);
-                var interruptsCommand = _sqlGenerator.Interrupt(storedIds);
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var sqlCommand = command.ToSqlCommand(conn);
 
-                var command = StoreCommand.Merge(appendMessagesCommand, interruptsCommand);
-
-                await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-                await using var sqlCommand = command.ToSqlCommand(conn);
-
-                await sqlCommand.ExecuteNonQueryAsync();
-                return; // Success - exit retry loop
-            }
-            catch (MySqlException ex) when (ex.ErrorCode == MySqlErrorCode.LockDeadlock && attempt < maxRetries)
-            {
-                lastException = ex;
-                // Deadlock detected - retry with exponential backoff
-                var delayMs = baseDelayMs * (1 << attempt) + Random.Shared.Next(0, baseDelayMs);
-                await Task.Delay(delayMs);
-                // Loop will retry
-            }
-        }
-
-        // All retries exhausted - throw the last exception
-        throw new InvalidOperationException(
-            $"Failed to append {messages.Count} message(s) after {maxRetries} retries due to deadlocks",
-            lastException
-        );
+        await sqlCommand.ExecuteNonQueryAsync();
     }
 
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
@@ -169,40 +107,15 @@ public class MariaDbMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        const int maxRetries = 5;
-        const int baseDelayMs = 10;
-        MySqlException? lastException = null;
+        var appendCommand = _sqlGenerator.AppendMessages(messages);
+        var interruptCommand = _sqlGenerator.Interrupt(messages.Select(m => m.StoredId).Distinct());
 
-        for (var attempt = 0; attempt <= maxRetries; attempt++)
-        {
-            try
-            {
-                var appendCommand = _sqlGenerator.AppendMessages(messages);
-                var interruptCommand = _sqlGenerator.Interrupt(messages.Select(m => m.StoredId).Distinct());
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var command = StoreCommand
+            .Merge(appendCommand, interruptCommand)
+            .ToSqlCommand(conn);
 
-                await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-                await using var command = StoreCommand
-                    .Merge(appendCommand, interruptCommand)
-                    .ToSqlCommand(conn);
-
-                await command.ExecuteNonQueryAsync();
-                return; // Success - exit retry loop
-            }
-            catch (MySqlException ex) when (ex.ErrorCode == MySqlErrorCode.LockDeadlock && attempt < maxRetries)
-            {
-                lastException = ex;
-                // Deadlock detected - retry with exponential backoff
-                var delayMs = baseDelayMs * (1 << attempt) + Random.Shared.Next(0, baseDelayMs);
-                await Task.Delay(delayMs);
-                // Loop will retry
-            }
-        }
-
-        // All retries exhausted - throw the last exception
-        throw new InvalidOperationException(
-            $"Failed to append {messages.Count} message(s) after {maxRetries} retries due to deadlocks",
-            lastException
-        );
+        await command.ExecuteNonQueryAsync();
     }
 
     private string? _replaceMessageSql;

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -585,17 +585,18 @@ public class SqlGenerator(string tablePrefix)
     
     public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
     {
+        // Position on the supplied messages is ignored — the AUTO_INCREMENT column assigns it. Rows are listed
+        // in caller order so the assignment preserves message order.
         var sql = @$"
             INSERT INTO {tablePrefix}_messages
-                (id, position, content)
+                (id, content)
             VALUES
-                 {"(?, ?, ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
+                 {"(?, ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
 
         var command = StoreCommand.Create(sql);
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), position) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) in messages)
         {
             command.AddParameter(storedId.AsGuid.ToString("N"));
-            command.AddParameter(position);
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -37,11 +37,11 @@ public class PostgreSqlMessageStore : IMessageStore
         await using var conn = await CreateConnection();
         _initializeSql ??= @$"
             CREATE TABLE IF NOT EXISTS {tablePrefix}_messages (
+                position BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 id UUID,
-                position BIGINT,
-                content BYTEA,
-                PRIMARY KEY (id, position)
-            );";
+                content BYTEA
+            );
+            CREATE INDEX IF NOT EXISTS {tablePrefix}_messages_id_idx ON {tablePrefix}_messages (id);";
 
         var command = new NpgsqlCommand(_initializeSql, conn);
         await command.ExecuteNonQueryAsync();

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -455,20 +455,13 @@ public class SqlGenerator(string tablePrefix)
     private string? _appendMessagesSql;
     public StoreCommand AppendMessages(StoredId storedId, IEnumerable<StoredMessage> messages)
     {
-        // Computes per-message positions server-side so the SQL string is constant regardless of batch size.
-        // max_pos: base = COALESCE(MAX(position), -1) + 2147483647 + $2 (random) — placed well above any
-        // existing position and randomized per call so concurrent appenders to the same flow rarely collide.
-        // unnest($3::bytea[]) WITH ORDINALITY expands the byte[][] parameter into rows with a 1-based offset,
-        // so each inserted row gets a unique position = base + pos_offset, in caller order.
+        // position is assigned by the table's identity column. unnest($2::bytea[]) WITH ORDINALITY expands the
+        // byte[][] parameter into rows; ORDER BY ord makes the identity assignment follow caller order.
         _appendMessagesSql ??= @$"
-            WITH max_pos AS (
-                SELECT COALESCE(MAX(position), -1) + 2147483647 + $2 AS pos
-                FROM {tablePrefix}_messages
-                WHERE id = $1
-            )
-            INSERT INTO {tablePrefix}_messages (id, position, content)
-            SELECT $1, (SELECT pos FROM max_pos) + pos_offset, content
-            FROM unnest($3::bytea[]) WITH ORDINALITY AS t(content, pos_offset);";
+            INSERT INTO {tablePrefix}_messages (id, content)
+            SELECT $1, content
+            FROM unnest($2::bytea[]) WITH ORDINALITY AS t(content, ord)
+            ORDER BY ord;";
 
         var contents = messages
             .Select(m => BinaryPacker.Pack(
@@ -484,26 +477,26 @@ public class SqlGenerator(string tablePrefix)
             _appendMessagesSql,
             values: [
                 storedId.AsGuid,
-                (long)Random.Shared.Next(),
                 contents
             ]
         );
     }
 
+    // Position on the supplied messages is ignored — the identity column assigns it. Rows are listed in caller
+    // order so identity assignment preserves message order.
     public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
     {
-        var sql = @$"    
+        var sql = @$"
             INSERT INTO {tablePrefix}_messages
-                (id, position, content)
-            VALUES 
-                 {messages.Select((_, i) => $"(${i * 3 + 1}, ${i * 3 + 2}, ${i * 3 + 3})").StringJoin($",{Environment.NewLine}")};";
+                (id, content)
+            VALUES
+                 {messages.Select((_, i) => $"(${i * 2 + 1}, ${i * 2 + 2})").StringJoin($",{Environment.NewLine}")};";
 
         var command = StoreCommand.Create(sql);
 
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), position) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) in messages)
         {
             command.AddParameter(storedId.AsGuid);
-            command.AddParameter(position);
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -575,16 +575,18 @@ public class SqlGenerator(string tablePrefix)
 
         var interruptCommand = Interrupt(messages.Select(m => m.StoredId).Distinct().ToList());
 
+        // Position on the supplied messages is ignored — the identity column assigns it. Rows are listed in
+        // caller order so identity assignment preserves message order.
         var sql = @$"
             INSERT INTO {tablePrefix}_Messages
-                (Id, Position, Content)
+                (Id, Content)
             VALUES
-                 {messages.Select((_, i) => $"(@{prefix}Id{i}, @{prefix}Position{i}, @{prefix}Content{i})").StringJoin($",{Environment.NewLine}")};";
+                 {messages.Select((_, i) => $"(@{prefix}Id{i}, @{prefix}Content{i})").StringJoin($",{Environment.NewLine}")};";
 
         var appendCommand = StoreCommand.Create(sql);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), position) = messages[i];
+            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) = messages[i];
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,
@@ -593,7 +595,6 @@ public class SqlGenerator(string tablePrefix)
                 receiver?.ToUtf8Bytes()
             );
             appendCommand.AddParameter($"@{prefix}Id{i}", storedId.AsGuid);
-            appendCommand.AddParameter($"@{prefix}Position{i}", position);
             appendCommand.AddParameter($"@{prefix}Content{i}", content);
         }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -32,11 +32,11 @@ public class SqlServerMessageStore : IMessageStore
 
         _initializeSql ??= @$"
         CREATE TABLE {_tablePrefix}_Messages (
+            Position BIGINT IDENTITY(1,1) PRIMARY KEY,
             Id UNIQUEIDENTIFIER,
-            Position BIGINT,
-            Content VARBINARY(MAX),
-            PRIMARY KEY (Id, Position)
-        );";
+            Content VARBINARY(MAX)
+        );
+        CREATE INDEX {_tablePrefix}_Messages_Id ON {_tablePrefix}_Messages (Id);";
         var command = new SqlCommand(_initializeSql, conn);
         try
         {
@@ -61,23 +61,16 @@ public class SqlServerMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        var randomOffset = Random.Shared.Next();
-        var values = messages.Select((_, i) => $"(@Id, @MaxPos + {i + 1}, @Content{i})").StringJoin(", ");
+        var values = messages.Select((_, i) => $"(@Id, @Content{i})").StringJoin(", ");
 
         var sql = @$"
-            DECLARE @MaxPos BIGINT;
-            SELECT @MaxPos = COALESCE(MAX(Position), -1) + 2147483647 + @RandomOffset
-            FROM {_tablePrefix}_Messages
-            WHERE Id = @Id;
-
-            INSERT INTO {_tablePrefix}_Messages (Id, Position, Content)
+            INSERT INTO {_tablePrefix}_Messages (Id, Content)
             VALUES {values};";
 
         await using var conn = await CreateConnection();
         await using var command = new SqlCommand(sql, conn);
 
         command.Parameters.AddWithValue("@Id", storedId.AsGuid);
-        command.Parameters.AddWithValue("@RandomOffset", (long)randomOffset);
 
         for (var i = 0; i < messages.Count; i++)
         {
@@ -108,16 +101,15 @@ public class SqlServerMessageStore : IMessageStore
         }
 
         var storedIds = messages.Select(m => m.StoredId).Distinct().ToList();
-        var maxPositions = await GetMaxPositions(storedIds);
 
         var interuptsSql = _sqlGenerator.Interrupt(storedIds)!;
 
         await using var conn = await CreateConnection();
         var sql = @$"
             INSERT INTO {_tablePrefix}_Messages
-                (Id, Position, Content)
+                (Id, Content)
             VALUES
-                 {messages.Select((_, i) => $"(@Id{i}, @Position{i}, @Content{i})").StringJoin($",{Environment.NewLine}")};
+                 {messages.Select((_, i) => $"(@Id{i}, @Content{i})").StringJoin($",{Environment.NewLine}")};
 
             {interuptsSql.Sql}";
 
@@ -125,10 +117,8 @@ public class SqlServerMessageStore : IMessageStore
         for (var i = 0; i < messages.Count; i++)
         {
             var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver)) = messages[i];
-            var position = ++maxPositions[storedId];
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
             command.Parameters.AddWithValue($"@Id{i}", storedId.AsGuid);
-            command.Parameters.AddWithValue($"@Position{i}", position);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
         foreach (var (value, name) in interuptsSql.Parameters)


### PR DESCRIPTION
## Summary

Switches the messages table from a composite `(id, position)` primary key with an application-computed position to a **global identity column**:

```
position (identity / auto-increment) PRIMARY KEY,
id,
content
+ secondary index on (id)
```

This came out of a discussion about append performance. The old composite key led with a random GUID, so on the clustered-index engines (SQL Server, MariaDB/InnoDB) every insert landed at a random point → page splits / fragmentation. It also required computing a per-flow `position` without a cross-replica race, which is where most of the complexity lived.

## What this removes

- The `MAX(position) + int.MaxValue + Random` offset hack used to assign positions without a read-modify-write race (all three SQL stores).
- **MariaDB's deadlock retry loops** — the read-modify-write that deadlocked is gone, so plain inserts to an auto-increment table no longer need retrying.
- **SQL Server's `GetMaxPositions` pre-fetch** round-trip before bulk append.

Appends are now plain `INSERT (id, content)`; the DB assigns ordering. Rows are listed in caller order so identity assignment preserves message order.

## Scope / drift

Confined to the message-store layer. **`IMessageStore`, `FunctionStore`, and `QueueManager` are unchanged.** The `AppendMessages(WithPosition)` overload is kept but now ignores the supplied position — flow creation is already idempotent at the function-row level, so the create path is untouched. `WithPosition` + `GetMaxPositions` are now vestigial and can be removed in a follow-up (that cleanup would touch the 3 FunctionStores + interface).

In-memory store updated to match (global monotonic counter; `ReplaceMessage`/`GetMaxPositions` adjusted for non-dense positions).

## Tests

- One test (`EventsAreNotReplacedWhenPositionIsNotAsExpected`) hard-coded `position: 2` assuming dense 0-based positions; it now derives a non-existent position as `max(position) + 1`.
- Locally green: MessageStore suites for in-memory + all 3 SQL stores (27/27 each), and the full in-memory Messaging suite (56/56).

Letting the pipeline run the full SQL Server / MariaDB flow suites. Stress-test before/after comparison in progress.