### PR TITLE
Messages: remove vestigial position APIs after identity migration

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
@@ -71,10 +71,6 @@ public class MessageStoreTests :  TestTemplates.MessageStoreTests
         => EventSubscriptionPublishesFiltersOutEventsWithSameIdempotencyKeys(FunctionStoreFactory.Create());
 
     [TestMethod]
-    public override Task MaxPositionIsCorrectForAppendedMessages()
-        => MaxPositionIsCorrectForAppendedMessages(FunctionStoreFactory.Create());
-
-    [TestMethod]
     public override Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain()
         => AppendedMultipleMessagesAtOnceCanBeFetchedAgain(FunctionStoreFactory.Create());
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -589,73 +589,6 @@ public abstract class MessageStoreTests
         newEvents.Count.ShouldBe(0);
     }
     
-    public abstract Task MaxPositionIsCorrectForAppendedMessages();
-    protected async Task MaxPositionIsCorrectForAppendedMessages(Task<IFunctionStore> functionStoreTask)
-    {
-        var id1 = TestStoredId.Create();
-        var id2 = TestStoredId.Create(id1.Type);
-        var id3 = TestStoredId.Create();
-        
-        var functionStore = await functionStoreTask;
-        var session = await functionStore.CreateFunction(
-            id1,
-            "humanInstanceId",
-            Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: null
-        );
-        session.ShouldBeNull();
-        session = await functionStore.CreateFunction(
-            id2,
-            "humanInstanceId2",
-            Test.SimpleStoredParameter,
-            leaseExpiration: DateTime.UtcNow.Ticks,
-            postponeUntil: null,
-            timestamp: DateTime.UtcNow.Ticks,
-            parent: null,
-            owner: null
-        );
-        session.ShouldBeNull();
-        var messageStore = functionStore.MessageStore;
-
-        const string msg1 = "";
-        const string msg2 = "";
-
-        await messageStore.AppendMessage(
-            id1,
-            new StoredMessage(msg1.ToJsonByteArray(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
-        );
-        await messageStore.AppendMessage(
-            id1,
-            new StoredMessage(msg1.ToJsonByteArray(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
-        );
-
-        await messageStore.AppendMessage(
-            id2,
-            new StoredMessage(msg2.ToJsonByteArray(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
-        );
-
-        var maxPositions = await messageStore.GetMaxPositions([id1, id2, id3]);
-        maxPositions.Count.ShouldBe(3);
-
-        // Get actual messages to verify ordering is correct
-        var id1Messages = (await messageStore.GetMessages(id1)).ToList();
-        var id2Messages = (await messageStore.GetMessages(id2)).ToList();
-
-        // Verify positions match the last message in each flow
-        id1Messages.Count.ShouldBe(2);
-        maxPositions[id1].ShouldBe(id1Messages.Max(m => m.Position));
-
-        id2Messages.Count.ShouldBe(1);
-        maxPositions[id2].ShouldBe(id2Messages[0].Position);
-
-        // id3 has no messages, so max position should be -1
-        maxPositions[id3].ShouldBe(-1);
-    }   
-    
     public abstract Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain();
     protected async Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain(Task<IFunctionStore> functionStoreTask)
     {
@@ -795,9 +728,9 @@ public abstract class MessageStoreTests
         
         await messageStore.AppendMessages(
             [
-                new StoredIdAndMessageWithPosition(id1, msg1, Position: 0),
-                new StoredIdAndMessageWithPosition(id2, msg1, Position: 0),
-                new StoredIdAndMessageWithPosition(id1, msg2, Position: 1),
+                new StoredIdAndMessage(id1, msg1),
+                new StoredIdAndMessage(id2, msg1),
+                new StoredIdAndMessage(id1, msg2),
             ]
         );
 
@@ -824,7 +757,7 @@ public abstract class MessageStoreTests
 
         await messageStore.AppendMessages(
             [
-                new StoredIdAndMessageWithPosition(id2, msg2, Position: 1)
+                new StoredIdAndMessage(id2, msg2)
             ]
         );
         

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -10,7 +10,6 @@ public interface IMessageStore
 
     Task AppendMessage(StoredId storedId, StoredMessage storedMessage);
     Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages);
-    Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages);
 
     Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage);
     Task DeleteMessages(StoredId storedId, IEnumerable<long> positions);
@@ -20,5 +19,4 @@ public interface IMessageStore
     Task<IReadOnlyList<StoredMessage>> GetMessages(StoredId storedId);
     Task<IReadOnlyList<StoredMessage>> GetMessages(StoredId storedId, IReadOnlyList<long> skipPositions);
     Task<Dictionary<StoredId, List<StoredMessage>>> GetMessages(IEnumerable<StoredId> storedIds);
-    Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds);
 }

--- a/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
@@ -10,7 +10,6 @@ public record StoredMessage(byte[] MessageContent, byte[] MessageType, long Posi
     public object DefaultDeserialize() => JsonSerializer.Deserialize(MessageContent, Type.GetType(MessageType.ToStringFromUtf8Bytes(), throwOnError: true)!)!; //todo remove
 }
 
-public record StoredIdAndMessageWithPosition(StoredId StoredId, StoredMessage StoredMessage, long Position);
 public record StoredIdAndMessage(StoredId StoredId, StoredMessage StoredMessage);
 public static class StoredIdAndMessageExtensions
 {

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -605,21 +605,6 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         }
     }
 
-    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
-    {
-        foreach (var (storedId, storedMessage, _) in messages)
-        {
-            lock (_sync)
-            {
-                if (!_messages.ContainsKey(storedId))
-                    _messages[storedId] = new Dictionary<long, StoredMessage>();
-
-                _messages[storedId].Add(_nextMessagePosition++, storedMessage);
-            }
-
-            await Interrupt(storedId);
-        }
-    }
 
     public Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage)
     {
@@ -679,18 +664,6 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         }
 
         return dict;
-    }
-
-    public Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds)
-    {
-        IDictionary<StoredId, long> positions = new Dictionary<StoredId, long>();
-        lock (_sync)
-            foreach (var storedId in storedIds)
-                positions[storedId] = _messages.TryGetValue(storedId, out var messages) && messages.Count > 0
-                    ? messages.Keys.Max()
-                    : -1;
-
-        return positions.ToTask();
     }
 
     #endregion

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
@@ -66,10 +66,6 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
         => EventSubscriptionPublishesFiltersOutEventsWithSameIdempotencyKeys(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task MaxPositionIsCorrectForAppendedMessages()
-        => MaxPositionIsCorrectForAppendedMessages(FunctionStoreFactory.Create());
-    
-    [TestMethod]
     public override Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain()
         => AppendedMultipleMessagesAtOnceCanBeFetchedAgain(FunctionStoreFactory.Create());
     

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbFunctionStore.cs
@@ -133,7 +133,7 @@ public class MariaDbFunctionStore : IFunctionStore
             var storeCommand = _sqlGenerator.CreateFunction(storedId, humanInstanceId, param, leaseExpiration, postponeUntil, timestamp, parent, owner, ignoreDuplicate: false, effects: effectsBytes);
 
             var messagesCommand = _sqlGenerator.AppendMessages(
-                messages.Select((msg, position) => new StoredIdAndMessageWithPosition(storedId, msg, position)).ToList()
+                messages.Select(msg => new StoredIdAndMessage(storedId, msg)).ToList()
             );
             storeCommand = storeCommand.Merge(messagesCommand);
 

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -87,11 +87,8 @@ public class MariaDbMessageStore : IMessageStore
             return;
 
         var storedIds = messages.Select(m => m.StoredId).Distinct().ToList();
-        var messagesWithPosition = messages
-            .Select(msg => new StoredIdAndMessageWithPosition(msg.StoredId, msg.StoredMessage, Position: 0))
-            .ToList();
 
-        var appendMessagesCommand = _sqlGenerator.AppendMessages(messagesWithPosition);
+        var appendMessagesCommand = _sqlGenerator.AppendMessages(messages);
         var interruptsCommand = _sqlGenerator.Interrupt(storedIds);
 
         var command = StoreCommand.Merge(appendMessagesCommand, interruptsCommand);
@@ -100,22 +97,6 @@ public class MariaDbMessageStore : IMessageStore
         await using var sqlCommand = command.ToSqlCommand(conn);
 
         await sqlCommand.ExecuteNonQueryAsync();
-    }
-
-    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
-    {
-        if (messages.Count == 0)
-            return;
-
-        var appendCommand = _sqlGenerator.AppendMessages(messages);
-        var interruptCommand = _sqlGenerator.Interrupt(messages.Select(m => m.StoredId).Distinct());
-
-        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        await using var command = StoreCommand
-            .Merge(appendCommand, interruptCommand)
-            .ToSqlCommand(conn);
-
-        await command.ExecuteNonQueryAsync();
     }
 
     private string? _replaceMessageSql;
@@ -221,32 +202,6 @@ public class MariaDbMessageStore : IMessageStore
             storedMessages[id].Add(ConvertToStoredMessage(content, position));
 
         return storedMessages;
-    }
-
-    public async Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds)
-    {
-        var sql = @$"
-            SELECT id, MAX(position)
-            FROM {_tablePrefix}_messages
-            WHERE Id IN ({storedIds.Select(id => $"'{id.AsGuid:N}'").StringJoin(", ")})
-            GROUP BY id;";
-
-        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        await using var command = new MySqlCommand(sql, conn);
-
-        var positions = new Dictionary<StoredId, long>(capacity: storedIds.Count);
-        foreach (var storedId in storedIds)
-            positions[storedId] = -1;
-
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            var storedId = new StoredId(reader.GetString(0).ToGuid());
-            var position = reader.GetInt64(1);
-            positions[storedId] = position;
-        }
-
-        return positions;
     }
 
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position)

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -583,10 +583,10 @@ public class SqlGenerator(string tablePrefix)
         return (null, null);
     }
     
-    public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
+    public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
-        // Position on the supplied messages is ignored — the AUTO_INCREMENT column assigns it. Rows are listed
-        // in caller order so the assignment preserves message order.
+        // The AUTO_INCREMENT column assigns position. Rows are listed in caller order so the assignment
+        // preserves message order.
         var sql = @$"
             INSERT INTO {tablePrefix}_messages
                 (id, content)
@@ -594,7 +594,7 @@ public class SqlGenerator(string tablePrefix)
                  {"(?, ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
 
         var command = StoreCommand.Create(sql);
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver)) in messages)
         {
             command.AddParameter(storedId.AsGuid.ToString("N"));
             var content = BinaryPacker.Pack(

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
@@ -67,10 +67,6 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
         => EventSubscriptionPublishesFiltersOutEventsWithSameIdempotencyKeys(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task MaxPositionIsCorrectForAppendedMessages()
-        => MaxPositionIsCorrectForAppendedMessages(FunctionStoreFactory.Create());
-    
-    [TestMethod]
     public override Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain()
         => AppendedMultipleMessagesAtOnceCanBeFetchedAgain(FunctionStoreFactory.Create());
     

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlFunctionStore.cs
@@ -164,7 +164,7 @@ public class PostgreSqlFunctionStore : IFunctionStore
 
             if (messages?.Any() ?? false)
                 commands.AddRange(_sqlGenerator.AppendMessages(
-                        messages.Select((msg, position) => new StoredIdAndMessageWithPosition(storedId, msg, position)).ToList()
+                        messages.Select(msg => new StoredIdAndMessage(storedId, msg)).ToList()
                     )
                 );
 

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -80,22 +80,6 @@ public class PostgreSqlMessageStore : IMessageStore
         await batch.ExecuteNonQueryAsync();
     }
 
-    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
-    {
-        if (messages.Count == 0)
-            return;
-
-        var appendMessagesCommand = sqlGenerator.AppendMessages(messages);
-        var interruptCommand = sqlGenerator.Interrupt(messages.Select(m => m.StoredId).Distinct());
-
-        await using var conn = await CreateConnection();
-        await using var command = StoreCommandExtensions
-            .ToNpgsqlBatch([appendMessagesCommand, interruptCommand])
-            .WithConnection(conn);
-
-        await command.ExecuteNonQueryAsync();
-    }
-
     private string? _replaceMessageSql;
     public async Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage)
     {
@@ -208,35 +192,5 @@ public class PostgreSqlMessageStore : IMessageStore
             receiver?.ToStringFromUtf8Bytes()
         );
         return storedMessage;
-    }
-
-    public async Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds)
-    {
-        if (storedIds.Count == 0)
-            return new Dictionary<StoredId, long>();
-
-        var sql = @$"
-            SELECT id, MAX(position)
-            FROM {tablePrefix}_messages
-            WHERE Id = ANY($1)
-            GROUP BY id;";
-
-        await using var conn = await CreateConnection();
-        await using var command = new NpgsqlCommand(sql, conn);
-        command.Parameters.Add(new NpgsqlParameter { Value = storedIds.Select(id => id.AsGuid).ToArray() });
-
-        var positions = new Dictionary<StoredId, long>(capacity: storedIds.Count);
-        foreach (var storedId in storedIds)
-            positions[storedId] = -1;
-
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            var storedId =  new StoredId(reader.GetGuid(0));
-            var position = reader.GetInt64(1);
-            positions[storedId] = position;
-        }
-
-        return positions;
     }
 }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -482,9 +482,9 @@ public class SqlGenerator(string tablePrefix)
         );
     }
 
-    // Position on the supplied messages is ignored — the identity column assigns it. Rows are listed in caller
-    // order so identity assignment preserves message order.
-    public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
+    // The identity column assigns position. Rows are listed in caller order so identity assignment preserves
+    // message order.
+    public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         var sql = @$"
             INSERT INTO {tablePrefix}_messages
@@ -494,7 +494,7 @@ public class SqlGenerator(string tablePrefix)
 
         var command = StoreCommand.Create(sql);
 
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver)) in messages)
         {
             command.AddParameter(storedId.AsGuid);
             var content = BinaryPacker.Pack(

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
@@ -67,10 +67,6 @@ public class MessageStoreTests :  Cleipnir.ResilientFunctions.Tests.Messaging.Te
         => EventSubscriptionPublishesFiltersOutEventsWithSameIdempotencyKeys(FunctionStoreFactory.Create());
     
     [TestMethod]
-    public override Task MaxPositionIsCorrectForAppendedMessages()
-        => MaxPositionIsCorrectForAppendedMessages(FunctionStoreFactory.Create());
-    
-    [TestMethod]
     public override Task AppendedMultipleMessagesAtOnceCanBeFetchedAgain()
         => AppendedMultipleMessagesAtOnceCanBeFetchedAgain(FunctionStoreFactory.Create());
     

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -568,15 +568,15 @@ public class SqlGenerator(string tablePrefix)
         return (null, null);
     }
     
-    public StoreCommand? AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages, string prefix = "")
+    public StoreCommand? AppendMessages(IReadOnlyList<StoredIdAndMessage> messages, string prefix = "")
     {
         if (messages.Count == 0)
             return null;
 
         var interruptCommand = Interrupt(messages.Select(m => m.StoredId).Distinct().ToList());
 
-        // Position on the supplied messages is ignored — the identity column assigns it. Rows are listed in
-        // caller order so identity assignment preserves message order.
+        // The identity column assigns position. Rows are listed in caller order so identity assignment
+        // preserves message order.
         var sql = @$"
             INSERT INTO {tablePrefix}_Messages
                 (Id, Content)
@@ -586,7 +586,7 @@ public class SqlGenerator(string tablePrefix)
         var appendCommand = StoreCommand.Create(sql);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver), _) = messages[i];
+            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver)) = messages[i];
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerFunctionStore.cs
@@ -167,7 +167,7 @@ public class SqlServerFunctionStore : IFunctionStore
             if (messages?.Any() ?? false)
             {
                 var messagesCommand = _sqlGenerator.AppendMessages(
-                    messages.Select((msg, position) => new StoredIdAndMessageWithPosition(storedId, msg, position)).ToList(),
+                    messages.Select(msg => new StoredIdAndMessage(storedId, msg)).ToList(),
                     prefix: "Message"
                 );
                 storeCommand = storeCommand.Merge(messagesCommand);

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -127,18 +127,6 @@ public class SqlServerMessageStore : IMessageStore
         await command.ExecuteNonQueryAsync();
     }
 
-    public async Task AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition> messages)
-    {
-        if (messages.Count == 0)
-            return;
-
-        await using var conn = await CreateConnection();
-        await using var command = _sqlGenerator
-            .AppendMessages(messages)!
-            .ToSqlCommand(conn);
-        await command.ExecuteNonQueryAsync();
-    }
-
     private string? _replaceMessageSql;
     public async Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage)
     {
@@ -229,37 +217,6 @@ public class SqlServerMessageStore : IMessageStore
                 storedMessages[id].Add(ConvertToStoredMessage(content, position));
 
         return storedMessages;
-    }
-
-    public async Task<IDictionary<StoredId, long>> GetMaxPositions(IReadOnlyList<StoredId> storedIds)
-    {
-        if (storedIds.Count == 0)
-            return new Dictionary<StoredId, long>();
-
-        var sql = @$"
-            SELECT Id, MAX(Position)
-            FROM {_tablePrefix}_Messages
-            WHERE Id IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Ids, ','))
-            GROUP BY Id;";
-
-        await using var conn = await CreateConnection();
-        await using var command = new SqlCommand(sql, conn);
-        command.Parameters.AddWithValue("@Ids", storedIds.ToCommaSeparatedIds());
-
-        var positions = new Dictionary<StoredId, long>(capacity: storedIds.Count);
-        foreach (var storedId in storedIds)
-            positions[storedId] = -1;
-
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            var id = reader.GetGuid(0);
-            var storedId = new StoredId(id);
-            var position = reader.GetInt64(1);
-            positions[storedId] = position;
-        }
-
-        return positions;
     }
 
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position)


### PR DESCRIPTION
## Summary

Follow-up cleanup to #155. Now that message `position` is assigned by the identity column, the caller-supplied-position machinery is dead weight. This removes it:

- `IMessageStore.AppendMessages(IReadOnlyList<StoredIdAndMessageWithPosition>)`
- `IMessageStore.GetMaxPositions(...)` — no production callers remained after #155 (it had only been used to pre-compute positions for the SQL Server / MariaDB bulk append)
- the `StoredIdAndMessageWithPosition` record

## Mechanics

- The `SqlGenerator.AppendMessages` overload used by the flow-creation path now takes `IReadOnlyList<StoredIdAndMessage>` instead of `...WithPosition` — its body already ignored the position. The three `FunctionStore` create paths and MariaDB's bulk append are updated to build `StoredIdAndMessage`. **No behavioural change** — the identity column still assigns `position` in insert order.
- Removed the now-redundant `MaxPositionIsCorrectForAppendedMessages` test (template + 4 store overrides) and switched the batched-append test to the `StoredIdAndMessage` overload.

## Scope

`IMessageStore` is the only public surface touched. `FunctionStore` and `QueueManager` behaviour is unchanged.

Net: **−268 / +23** lines across 17 files.

## Tests

Locally green: MessageStore suites for in-memory + all three SQL stores (26 each), and the in-memory Messaging suite (55). Letting the pipeline run the full SQL Server / MariaDB flow suites.