### PR TITLE
Resolve message replica to target flow owner, falling back to non-null publisher replica

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -37,12 +37,12 @@ public abstract class MessageStoreTests
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage(msg1.ToJsonByteArray(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage(msg1.ToJsonByteArray(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage(msg2.ToJsonByteArray(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage(msg2.ToJsonByteArray(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         var events = (await messageStore.GetMessages(functionId)).ToList();
@@ -74,13 +74,13 @@ public abstract class MessageStoreTests
         const string msg3 = "hello universe";
         const string msg4 = "hello multiverse";
         
-        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "1");
-        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "2");
+        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2");
         await messageStore.AppendMessage(functionId, storedEvent1);
         await messageStore.AppendMessage(functionId, storedEvent2);
 
-        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "3");
-        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: null);
+        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "3");
+        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: null);
         await messageStore.AppendMessage(functionId, storedEvent3);
         await messageStore.AppendMessage(functionId, storedEvent4);
         
@@ -117,16 +117,16 @@ public abstract class MessageStoreTests
         const string msg3 = "hello universe";
         const string msg4 = "hello multiverse";
 
-        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "1");
-        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "2");
+        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2");
         await messageStore.AppendMessage(functionId, storedEvent1);
         await messageStore.AppendMessage(functionId, storedEvent2);
 
         var existingMessages = await messageStore.GetMessages(functionId).ToListAsync();
         existingMessages.Count.ShouldBe(2);
 
-        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[0].Position, IdempotencyKey: "3");
-        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[1].Position, IdempotencyKey: null);
+        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[0].Position, ReplicaId.Empty, IdempotencyKey: "3");
+        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[1].Position, ReplicaId.Empty, IdempotencyKey: null);
         await messageStore.ReplaceMessage(functionId, existingMessages[0].Position, storedEvent3).ShouldBeTrueAsync();
         await messageStore.ReplaceMessage(functionId, existingMessages[1].Position, storedEvent4).ShouldBeTrueAsync();
 
@@ -159,16 +159,16 @@ public abstract class MessageStoreTests
         const string msg3 = "hello universe";
         const string msg4 = "hello multiverse";
 
-        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "1");
-        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "2");
+        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2");
         await messageStore.AppendMessage(functionId, storedEvent1);
         await messageStore.AppendMessage(functionId, storedEvent2);
 
         var existingMessages = await messageStore.GetMessages(functionId).ToListAsync();
         existingMessages.Count.ShouldBe(2);
 
-        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[0].Position, IdempotencyKey: "3");
-        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[1].Position, IdempotencyKey: null);
+        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[0].Position, ReplicaId.Empty, IdempotencyKey: "3");
+        var storedEvent4 = new StoredMessage(msg4.ToJson().ToUtf8Bytes(), msg4.GetType().SimpleQualifiedName().ToUtf8Bytes(), existingMessages[1].Position, ReplicaId.Empty, IdempotencyKey: null);
         await messageStore.ReplaceMessage(functionId, existingMessages[0].Position, storedEvent3).ShouldBeTrueAsync();
         await messageStore.ReplaceMessage(functionId, existingMessages[1].Position, storedEvent4).ShouldBeTrueAsync();
 
@@ -200,8 +200,8 @@ public abstract class MessageStoreTests
         const string msg2 = "hello world";
         const string msg3 = "hello universe";
         
-        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "1");
-        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "2");
+        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2");
         await messageStore.AppendMessage(functionId, storedEvent1);
         await messageStore.AppendMessage(functionId, storedEvent2);
 
@@ -210,7 +210,7 @@ public abstract class MessageStoreTests
             .SelectAsync(events => events.Count())
             .ShouldBeAsync(2);
         
-        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "3");
+        var storedEvent3 = new StoredMessage(msg3.ToJson().ToUtf8Bytes(), msg3.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "3");
         var nonExistentPosition = (await messageStore.GetMessages(functionId)).Max(m => m.Position) + 1;
         await messageStore.ReplaceMessage(functionId, nonExistentPosition, storedEvent3).ShouldBeFalseAsync();
         
@@ -241,8 +241,8 @@ public abstract class MessageStoreTests
         const string msg1 = "hello world";
         const string msg2 = "hello universe";
 
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var events = (await messageStore.GetMessages(functionId)).Skip(1).ToList();
         events.Count.ShouldBe(1);
@@ -269,8 +269,8 @@ public abstract class MessageStoreTests
         const string msg1 = "hello here";
         const string msg2 = "hello world";
 
-        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "1");
-        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Position: 0, IdempotencyKey: "2");
+        var storedEvent1 = new StoredMessage(msg1.ToJson().ToUtf8Bytes(), msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var storedEvent2 = new StoredMessage(msg2.ToJson().ToUtf8Bytes(), msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2");
         await messageStore.AppendMessage(functionId, storedEvent1);
         await messageStore.AppendMessage(functionId, storedEvent2);
 
@@ -318,17 +318,17 @@ public abstract class MessageStoreTests
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         await messageStore.Truncate(functionId);
-        await messageStore.AppendMessage(functionId, new StoredMessage("hello to you".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage("hello from me".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage("hello to you".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage("hello from me".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var events = (await messageStore.GetMessages(functionId)).ToList();
         events.Count.ShouldBe(2);
@@ -356,8 +356,8 @@ public abstract class MessageStoreTests
         var messageStore = functionStore.MessageStore;
 
         await messageStore.Truncate(functionId);
-        await messageStore.AppendMessage(functionId, new StoredMessage("hello to you".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage("hello from me".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage("hello to you".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage("hello from me".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var events = (await messageStore.GetMessages(functionId)).ToList();
         events.Count.ShouldBe(2);
@@ -375,12 +375,14 @@ public abstract class MessageStoreTests
             JsonExtensions.ToJson("hello world").ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key"
         );
         var event2 = new StoredMessage(
             "hello universe".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key"
         );
         
@@ -415,12 +417,14 @@ public abstract class MessageStoreTests
             "hello world".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key"
         );
         var event2 = new StoredMessage(
             "hello universe".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key"
         );
         
@@ -487,6 +491,7 @@ public abstract class MessageStoreTests
             "hello world".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key_1"
         );
         await messageStore.AppendMessage(functionId, event1);
@@ -505,6 +510,7 @@ public abstract class MessageStoreTests
             "hello universe".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key_2"
         );
         await messageStore.AppendMessage(functionId, event2);
@@ -543,6 +549,7 @@ public abstract class MessageStoreTests
             "hello world".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key_1"
         );
         await messageStore.AppendMessage(functionId, event1);
@@ -561,6 +568,7 @@ public abstract class MessageStoreTests
             "hello universe".ToJson().ToUtf8Bytes(),
             typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key_1"
         );
         await messageStore.AppendMessage(functionId, event2);
@@ -608,10 +616,10 @@ public abstract class MessageStoreTests
         var msg1 = "Hello";
         var msg2 = "World";
         var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
-        await messageStore.AppendMessage(id1, new StoredMessage("ignore".ToJsonByteArray(), stringType, Position: 0));
-        var storedMsg1 = new StoredMessage(msg1.ToJsonByteArray(), stringType, Position: 0, IdempotencyKey: "1").ToStoredIdAndMessage(id1);
-        var storedMsg2 = new StoredMessage(msg2.ToJsonByteArray(), stringType, Position: 0, IdempotencyKey: "2").ToStoredIdAndMessage(id1);
-        var storedMsg3 = new StoredMessage(msg1.ToJsonByteArray(), stringType, Position: 0, IdempotencyKey: "3").ToStoredIdAndMessage(id2);
+        await messageStore.AppendMessage(id1, new StoredMessage("ignore".ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0));
+        var storedMsg1 = new StoredMessage(msg1.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1").ToStoredIdAndMessage(id1);
+        var storedMsg2 = new StoredMessage(msg2.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "2").ToStoredIdAndMessage(id1);
+        var storedMsg3 = new StoredMessage(msg1.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "3").ToStoredIdAndMessage(id2);
         await messageStore.AppendMessages([storedMsg1, storedMsg2, storedMsg3]);
 
         var id1Msgs = await messageStore.GetMessages(id1);
@@ -659,7 +667,7 @@ public abstract class MessageStoreTests
         var msg = "Hello World!";
         var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
         await messageStore.AppendMessages(
-            [new StoredMessage(msg.ToJsonByteArray(), stringType, Position: 0, IdempotencyKey: "1").ToStoredIdAndMessage(id)]
+            [new StoredMessage(msg.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1").ToStoredIdAndMessage(id)]
         );
 
         var messages = await messageStore.GetMessages(id);
@@ -705,8 +713,8 @@ public abstract class MessageStoreTests
         var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
         var msg1String = "Hello";
         var msg2String = "World!";
-        var msg1 = new StoredMessage(msg1String.ToUtf8Bytes(), stringType, Position: 0, IdempotencyKey: "1");
-        var msg2 = new StoredMessage(msg2String.ToUtf8Bytes(), stringType, Position: 0);
+        var msg1 = new StoredMessage(msg1String.ToUtf8Bytes(), stringType, Replica: ReplicaId.Empty, Position: 0, IdempotencyKey: "1");
+        var msg2 = new StoredMessage(msg2String.ToUtf8Bytes(), stringType, Replica: ReplicaId.Empty, Position: 0);
         
         await messageStore.AppendMessages(
             [
@@ -789,10 +797,10 @@ public abstract class MessageStoreTests
         var msg1 = "Hello";
         var msg2 = "World!";
         var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
-        await messageStore.AppendMessage(id1, new StoredMessage(msg1.ToJsonByteArray(), stringType, Position: 0));
-        await messageStore.AppendMessage(id1, new StoredMessage(msg2.ToJsonByteArray(), stringType, Position: 0));
-        await messageStore.AppendMessage(id2, new StoredMessage(msg1.ToJsonByteArray(), stringType, Position: 0));
-        await messageStore.AppendMessage(id2, new StoredMessage(msg2.ToJsonByteArray(), stringType, Position: 0));
+        await messageStore.AppendMessage(id1, new StoredMessage(msg1.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id1, new StoredMessage(msg2.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id2, new StoredMessage(msg1.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id2, new StoredMessage(msg2.ToJsonByteArray(), stringType, Replica: ReplicaId.Empty, Position: 0));
         
         var messages = await messageStore.GetMessages([id1, id2]);
         messages.Count.ShouldBe(2);
@@ -828,10 +836,10 @@ public abstract class MessageStoreTests
         const string msg3 = "message3";
         const string msg4 = "message4";
 
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg3.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg4.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg3.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg4.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var messages = (await messageStore.GetMessages(functionId)).ToList();
         messages.Count.ShouldBe(4);
@@ -864,8 +872,8 @@ public abstract class MessageStoreTests
         const string msg1 = "message1";
         const string msg2 = "message2";
 
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var messages = (await messageStore.GetMessages(functionId)).ToList();
         messages.Count.ShouldBe(2);
@@ -895,7 +903,7 @@ public abstract class MessageStoreTests
 
         const string msg1 = "message1";
 
-        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(functionId, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var messages = (await messageStore.GetMessages(functionId)).ToList();
         messages.Count.ShouldBe(1);
@@ -958,10 +966,10 @@ public abstract class MessageStoreTests
         const string msg2 = "message2";
 
         // Add messages to both functions
-        await messageStore.AppendMessage(id1, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(id1, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(id2, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await messageStore.AppendMessage(id2, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await messageStore.AppendMessage(id1, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id1, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id2, new StoredMessage(msg1.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await messageStore.AppendMessage(id2, new StoredMessage(msg2.ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         var messages1 = (await messageStore.GetMessages(id1)).ToList();
         messages1.Count.ShouldBe(2);
@@ -1004,6 +1012,7 @@ public abstract class MessageStoreTests
             msg1.ToJson().ToUtf8Bytes(),
             msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_1",
             Sender: "sender_1",
             Receiver: "receiver_1"
@@ -1012,6 +1021,7 @@ public abstract class MessageStoreTests
             msg2.ToJson().ToUtf8Bytes(),
             msg2.GetType().SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: null,
             Sender: "sender_2",
             Receiver: null
@@ -1020,6 +1030,7 @@ public abstract class MessageStoreTests
             msg1.ToJson().ToUtf8Bytes(),
             msg1.GetType().SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_3",
             Sender: null,
             Receiver: "receiver_3"
@@ -1077,6 +1088,7 @@ public abstract class MessageStoreTests
                         $"batch{batchIndex}_msg{msgIndex}".ToJsonByteArray(),
                         stringType,
                         Position: 0,
+                        Replica: ReplicaId.Empty,
                         IdempotencyKey: $"batch{batchIndex}_msg{msgIndex}"
                     ))
                     .ToList();
@@ -1149,8 +1161,8 @@ public abstract class MessageStoreTests
         await messageStore.AppendMessage(executingFlow, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher));
         // idle target -> falls back to the publishing replica
         await messageStore.AppendMessage(idleFlow, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher));
-        // idle target with no publisher replica -> null
-        await messageStore.AppendMessage(idleFlow, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0));
+        // idle target with empty publisher replica -> empty
+        await messageStore.AppendMessage(idleFlow, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: ReplicaId.Empty));
 
         // bulk append resolves per target flow
         await messageStore.AppendMessages([
@@ -1164,9 +1176,9 @@ public abstract class MessageStoreTests
 
         var idleMessages = (await messageStore.GetMessages(idleFlow)).ToList();
         idleMessages.Count.ShouldBe(3);
-        idleMessages[0].Replica.ShouldBe(publisher); // "b" - fallback
-        idleMessages[1].Replica.ShouldBeNull();      // "c" - no fallback
-        idleMessages[2].Replica.ShouldBe(publisher); // "e" - fallback
+        idleMessages[0].Replica.ShouldBe(publisher);          // "b" - fallback
+        idleMessages[1].Replica.ShouldBe(ReplicaId.Empty);    // "c" - empty fallback
+        idleMessages[2].Replica.ShouldBe(publisher);          // "e" - fallback
 
         // multi-storedId fetch path round-trips the resolved replica
         var byStoredId = await messageStore.GetMessages([executingFlow, idleFlow]);

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1143,15 +1143,19 @@ public abstract class MessageStoreTests
         );
 
         var messageStore = functionStore.MessageStore;
+        var publisher = ReplicaId.NewId(); // the publishing replica - used as fallback when the target is idle
 
-        // the Replica supplied by the caller is ignored - it is derived from the target flow's current owner
-        await messageStore.AppendMessage(executingFlow, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: ReplicaId.NewId()));
-        await messageStore.AppendMessage(idleFlow, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0));
+        // executing target -> the target flow's owner wins, the publisher fallback is ignored
+        await messageStore.AppendMessage(executingFlow, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher));
+        // idle target -> falls back to the publishing replica
+        await messageStore.AppendMessage(idleFlow, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher));
+        // idle target with no publisher replica -> null
+        await messageStore.AppendMessage(idleFlow, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0));
 
-        // bulk append derives the owner per target flow
+        // bulk append resolves per target flow
         await messageStore.AppendMessages([
-            new StoredIdAndMessage(executingFlow, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0)),
-            new StoredIdAndMessage(idleFlow, new StoredMessage("d".ToJson().ToUtf8Bytes(), stringType, Position: 0)),
+            new StoredIdAndMessage(executingFlow, new StoredMessage("d".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher)),
+            new StoredIdAndMessage(idleFlow, new StoredMessage("e".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: publisher)),
         ]);
 
         var executingMessages = (await messageStore.GetMessages(executingFlow)).ToList();
@@ -1159,22 +1163,32 @@ public abstract class MessageStoreTests
         executingMessages.ShouldAllBe(m => m.Replica == owner);
 
         var idleMessages = (await messageStore.GetMessages(idleFlow)).ToList();
-        idleMessages.Count.ShouldBe(2);
-        idleMessages.ShouldAllBe(m => m.Replica == null);
+        idleMessages.Count.ShouldBe(3);
+        idleMessages[0].Replica.ShouldBe(publisher); // "b" - fallback
+        idleMessages[1].Replica.ShouldBeNull();      // "c" - no fallback
+        idleMessages[2].Replica.ShouldBe(publisher); // "e" - fallback
 
-        // multi-storedId fetch path round-trips the same replica
+        // multi-storedId fetch path round-trips the resolved replica
         var byStoredId = await messageStore.GetMessages([executingFlow, idleFlow]);
         byStoredId[executingFlow].ShouldAllBe(m => m.Replica == owner);
-        byStoredId[idleFlow].ShouldAllBe(m => m.Replica == null);
 
-        // replacing a message re-derives the owner from the target flow
+        // replacing a message re-resolves: executing target keeps its owner ...
         await messageStore.ReplaceMessage(
             executingFlow,
             position: executingMessages[0].Position,
-            new StoredMessage("replaced".ToJson().ToUtf8Bytes(), stringType, Position: executingMessages[0].Position)
+            new StoredMessage("replaced".ToJson().ToUtf8Bytes(), stringType, Position: executingMessages[0].Position, Replica: publisher)
         );
-        var afterReplace = (await messageStore.GetMessages(executingFlow)).ToList();
-        afterReplace[0].DefaultDeserialize().ShouldBe("replaced");
-        afterReplace[0].Replica.ShouldBe(owner);
+        var afterReplaceExecuting = (await messageStore.GetMessages(executingFlow)).ToList();
+        afterReplaceExecuting[0].DefaultDeserialize().ShouldBe("replaced");
+        afterReplaceExecuting[0].Replica.ShouldBe(owner);
+
+        // ... while an idle target falls back to the publisher replica
+        await messageStore.ReplaceMessage(
+            idleFlow,
+            position: idleMessages[1].Position,
+            new StoredMessage("replaced".ToJson().ToUtf8Bytes(), stringType, Position: idleMessages[1].Position, Replica: publisher)
+        );
+        var afterReplaceIdle = (await messageStore.GetMessages(idleFlow)).ToList();
+        afterReplaceIdle.Single(m => m.Position == idleMessages[1].Position).Replica.ShouldBe(publisher);
     }
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -43,7 +43,7 @@ public abstract class MessagesSubscriptionTests
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello world". ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world". ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         events = await messageStore.GetMessages(functionId);
@@ -59,7 +59,7 @@ public abstract class MessagesSubscriptionTests
 
         await messageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         filteredEvents = (await messageStore.GetMessages(functionId)).Where(e => e.Position > skipPosition).ToList();

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -360,7 +360,7 @@ public abstract class MessagesTests
         var serializer = DefaultSerializer.Instance;
         var messageStore = functionStore.MessageStore;
 
-        var messageWriter = new MessageWriter(storedId, messageStore, serializer);
+        var messageWriter = new MessageWriter(storedId, messageStore, serializer, ReplicaId.NewId());
         await messageWriter.AppendMessage("hello world", idempotencyKey: "key1", sender: "TestSender");
 
         var messages = await messageStore.GetMessages(storedId);

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/ControlPanelTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/FunctionTests/ControlPanelTests.cs
@@ -715,7 +715,7 @@ public abstract class ControlPanelTests
         await rAction.Run(flowInstance.Value, param: "param");
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         var controlPanel = await rAction.ControlPanel(flowInstance).ShouldNotBeNullAsync();
@@ -724,7 +724,7 @@ public abstract class ControlPanelTests
 
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
         
         await existingMessages.Clear();
@@ -752,14 +752,14 @@ public abstract class ControlPanelTests
         await rAction.Run(flowInstance.Value, param: "param");
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         var controlPanel = await rAction.ControlPanel(flowInstance).ShouldNotBeNullAsync();
 
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         controlPanel.Param = "PARAM";
@@ -794,7 +794,7 @@ public abstract class ControlPanelTests
         await rAction.Run(flowInstance.Value, param: "param");
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         var controlPanel = await rAction.ControlPanel(flowInstance).ShouldNotBeNullAsync();
@@ -803,7 +803,7 @@ public abstract class ControlPanelTests
 
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
         
         await existingMessages.Clear();
@@ -831,14 +831,14 @@ public abstract class ControlPanelTests
         await rAction.Run(flowInstance.Value, param: "param");
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         var controlPanel = await rAction.ControlPanel(flowInstance).ShouldNotBeNullAsync();
 
         await store.MessageStore.AppendMessage(
             rAction.MapToStoredId(functionId.Instance),
-            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello universe".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         controlPanel.Param = "PARAM";

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreCrudTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreCrudTests.cs
@@ -180,7 +180,7 @@ public abstract class StoreCrudTests
             new StoredEffect(2.ToEffectId(), WorkStatus.Completed, Result: null, StoredException: null, Alias: null).ToStoredChange(storedId, Insert),
             session: null
         );
-        await store.MessageStore.AppendMessage(storedId, new StoredMessage("SomeJson".ToUtf8Bytes(), "SomeType".ToUtf8Bytes(), Position: 0));
+        await store.MessageStore.AppendMessage(storedId, new StoredMessage("SomeJson".ToUtf8Bytes(), "SomeType".ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
 
         await store.DeleteFunction(storedId);
 
@@ -493,12 +493,14 @@ public abstract class StoreCrudTests
             MessageContent: "message1".ToUtf8Bytes(),
             MessageType: "Type1".ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: null
         );
         var message2 = new StoredMessage(
             MessageContent: "message2".ToUtf8Bytes(),
             MessageType: "Type2".ToUtf8Bytes(),
             Position: 1,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: null
         );
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/TestTemplates/StoreTests.cs
@@ -536,6 +536,7 @@ public abstract class StoreTests
             "hello everyone".ToJson().ToUtf8Bytes(),
             MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "idempotency_key_1"
         );
         await messages.AppendMessage(functionId, message1);
@@ -601,7 +602,7 @@ public abstract class StoreTests
 
         await store.MessageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
     }
     
@@ -613,7 +614,7 @@ public abstract class StoreTests
         
         await store.MessageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
     }
     
@@ -732,8 +733,8 @@ public abstract class StoreTests
         );
         session.ShouldBeNull();
 
-        await store.MessageStore.AppendMessage(functionId, new StoredMessage("Hello".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
-        await store.MessageStore.AppendMessage(functionId, new StoredMessage("World".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0));
+        await store.MessageStore.AppendMessage(functionId, new StoredMessage("Hello".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
+        await store.MessageStore.AppendMessage(functionId, new StoredMessage("World".ToJson().ToUtf8Bytes(), MessageType: typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0));
         
         var messages = await store.MessageStore.GetMessages(functionId);
         messages.Count.ShouldBe(2);
@@ -912,7 +913,7 @@ public abstract class StoreTests
 
         await store.MessageStore.AppendMessage(
             functionId,
-            new StoredMessage("some message".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("some message".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         await store.Interrupt(functionId);
@@ -950,7 +951,7 @@ public abstract class StoreTests
 
         await store.MessageStore.AppendMessage(
             functionId,
-            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Position: 0)
+            new StoredMessage("hello world".ToJson().ToUtf8Bytes(), typeof(string).SimpleQualifiedName().ToUtf8Bytes(), Replica: ReplicaId.Empty, Position: 0)
         );
 
         await store.Interrupt(functionId);
@@ -1469,12 +1470,14 @@ public abstract class StoreTests
             MessageContent: "hallo world".ToUtf8Bytes(),
             MessageType: "some type".ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "some idempotency key"
         );
         var message2 = new StoredMessage(
             MessageContent: "hallo universe".ToUtf8Bytes(),
             MessageType: "some type".ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "some idempotency key"
         );
 
@@ -1538,12 +1541,14 @@ public abstract class StoreTests
             MessageContent: "hallo world".ToUtf8Bytes(),
             MessageType: "some type".ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "some idempotency key"
         );
         var message2 = new StoredMessage(
             MessageContent: "hallo universe".ToUtf8Bytes(),
             MessageType: "some type".ToUtf8Bytes(),
             Position: 0,
+            Replica: ReplicaId.Empty,
             IdempotencyKey: "some idempotency key"
         );
 
@@ -1677,7 +1682,8 @@ public abstract class StoreTests
             new StoredMessage(
                 "hallo message".ToUtf8Bytes(),
                 typeof(string).SimpleQualifiedName().ToUtf8Bytes(),
-                Position: 0
+                Position: 0,
+                Replica: ReplicaId.Empty
             )
         );
 

--- a/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/MessageBatcherTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/UtilsTests/MessageBatcherTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Storage;
@@ -318,6 +319,7 @@ public class MessageBatcherTests
     private static StoredMessage CreateMessage(string content) => new(
         Encoding.UTF8.GetBytes(content),
         Encoding.UTF8.GetBytes("System.String"),
-        Position: 0
+        Position: 0,
+        Replica: ReplicaId.Empty
     );
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -203,7 +203,7 @@ internal class InvocationHelper<TParam, TReturn>
 
         var content = Serializer.Serialize(msg, msg.GetType());
         var type = Serializer.SerializeType(msg.GetType());
-        var storedMessage = new StoredMessage(content, type, Position: 0, IdempotencyKey: $"FlowCompleted:{childId}");
+        var storedMessage = new StoredMessage(content, type, Position: 0, IdempotencyKey: $"FlowCompleted:{childId}", Replica: _replicaId);
         await _functionStore.MessageStore.AppendMessage(parent, storedMessage);
         await _functionStore.Interrupt(parent);
     }
@@ -382,7 +382,7 @@ internal class InvocationHelper<TParam, TReturn>
     }
     
     public MessageWriter CreateMessageWriter(StoredId storedId)
-        => new MessageWriter(storedId, _functionStore.MessageStore, Serializer);
+        => new MessageWriter(storedId, _functionStore.MessageStore, Serializer, _replicaId);
 
     public Effect CreateEffect(StoredId storedId, FlowId flowId, IReadOnlyList<StoredEffect> storedEffects, FlowTimeouts flowTimeouts, IStorageSession? storageSession, FlowState flowState)
     {

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -489,7 +489,7 @@ internal class InvocationHelper<TParam, TReturn>
         {
             var content = Serializer.Serialize(m.Message, m.Message.GetType());
             var type = Serializer.SerializeType(m.Message.GetType());
-            return new StoredMessage(content, type, Position: 0, m.IdempotencyKey);
+            return new StoredMessage(content, type, Position: 0, Replica: _replicaId, IdempotencyKey: m.IdempotencyKey);
         }).ToList();
 
     internal IReadOnlyList<StoredMessage> AddPositionsToMessages(IReadOnlyList<StoredMessage> messages)

--- a/Core/Cleipnir.ResilientFunctions/Domain/ExistingMessages.cs
+++ b/Core/Cleipnir.ResilientFunctions/Domain/ExistingMessages.cs
@@ -56,7 +56,7 @@ public class ExistingMessages
         var json = _serializer.Serialize(message, message.GetType());
         var type = _serializer.SerializeType(message.GetType());
         await _messageStore.AppendMessage(
-            _storedId, new StoredMessage(json, type, Position: 0, idempotencyKey)
+            _storedId, new StoredMessage(json, type, Position: 0, Replica: ReplicaId.Empty, IdempotencyKey: idempotencyKey)
         );
 
         // Invalidate cache so it will be re-fetched with correct positions
@@ -74,7 +74,7 @@ public class ExistingMessages
 
         var json = _serializer.Serialize(message, message.GetType());
         var type = _serializer.SerializeType(message.GetType());
-        await _messageStore.ReplaceMessage(_storedId, storedMessage.Position, new StoredMessage(json, type, Position: storedMessage.Position, idempotencyKey));
+        await _messageStore.ReplaceMessage(_storedId, storedMessage.Position, new StoredMessage(json, type, Position: storedMessage.Position, Replica: ReplicaId.Empty, IdempotencyKey: idempotencyKey));
 
         // Invalidate cache so it will be re-fetched with correct data
         _receivedMessages = null;

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -268,7 +268,8 @@ public class FunctionsRegistry : IDisposable
             var messageWriters = new MessageWriters(
                 storedType,
                 _functionStore,
-                serializer
+                serializer,
+                ClusterInfo.ReplicaId
             );
 
             var registration = new FuncRegistration<TParam, TReturn>(
@@ -350,7 +351,8 @@ public class FunctionsRegistry : IDisposable
             var messageWriters = new MessageWriters(
                 storedType,
                 _functionStore,
-                serializer
+                serializer,
+                ClusterInfo.ReplicaId
             );
 
             var registration = new ParamlessRegistration(
@@ -432,7 +434,8 @@ public class FunctionsRegistry : IDisposable
             var messageWriters = new MessageWriters(
                 storedType,
                 _functionStore,
-                serializer
+                serializer,
+                ClusterInfo.ReplicaId
             );
             var registration = new ActionRegistration<TParam>(
                 flowType,

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
+using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.Messaging;
 
-public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer)
+public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer, ReplicaId? publisherReplica = null)
 {
     public async Task AppendMessage<TMessage>(TMessage message, string? idempotencyKey = null, string? sender = null, string? receiver = null) where TMessage : class
     {
@@ -13,7 +14,7 @@ public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISer
 
          await messageStore.AppendMessage(
             storedIdId,
-            new StoredMessage(eventJson, eventType, Position: 0, idempotencyKey, Sender: sender, Receiver: receiver)
+            new StoredMessage(eventJson, eventType, Position: 0, idempotencyKey, Sender: sender, Receiver: receiver, Replica: publisherReplica)
         );
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
@@ -5,7 +5,7 @@ using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.Messaging;
 
-public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer, ReplicaId? publisherReplica = null)
+public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer, ReplicaId publisherReplica)
 {
     public async Task AppendMessage<TMessage>(TMessage message, string? idempotencyKey = null, string? sender = null, string? receiver = null) where TMessage : class
     {

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
@@ -14,7 +14,7 @@ public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISer
 
          await messageStore.AppendMessage(
             storedIdId,
-            new StoredMessage(eventJson, eventType, Position: 0, idempotencyKey, Sender: sender, Receiver: receiver, Replica: publisherReplica)
+            new StoredMessage(eventJson, eventType, Position: 0, Replica: publisherReplica, IdempotencyKey: idempotencyKey, Sender: sender, Receiver: receiver)
         );
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
@@ -45,7 +45,7 @@ public class MessageWriters
             var storedId = StoredId.Create(_storedType, instance.Value);
             var content = _serializer.Serialize(message, message.GetType());
             var type = _serializer.SerializeType(message.GetType());
-            var storedMessage = new StoredMessage(content, type, Position: 0, idempotencyKey, Replica: _publisherReplica);
+            var storedMessage = new StoredMessage(content, type, Position: 0, Replica: _publisherReplica, IdempotencyKey: idempotencyKey);
             storedIdAndMessages.Add(new StoredIdAndMessage(storedId,storedMessage));
         }
 

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
@@ -12,26 +12,29 @@ public class MessageWriters
     private readonly StoredType _storedType;
     private readonly IFunctionStore _functionStore;
     private readonly ISerializer _serializer;
+    private readonly ReplicaId _publisherReplica;
 
     public MessageWriters(
         StoredType storedType,
-        IFunctionStore functionStore, 
-        ISerializer serializer)
+        IFunctionStore functionStore,
+        ISerializer serializer,
+        ReplicaId publisherReplica)
     {
         _storedType = storedType;
         _functionStore = functionStore;
         _serializer = serializer;
+        _publisherReplica = publisherReplica;
     }
 
     public MessageWriter For(FlowInstance instance)
     {
         var storedId = StoredId.Create(_storedType, instance.Value);
-        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer);
+        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica);
     }
-    
+
     internal MessageWriter For(StoredId storedId)
     {
-        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer);
+        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica);
     }
 
     public async Task AppendMessages(IReadOnlyList<BatchedMessage> messages)
@@ -42,10 +45,10 @@ public class MessageWriters
             var storedId = StoredId.Create(_storedType, instance.Value);
             var content = _serializer.Serialize(message, message.GetType());
             var type = _serializer.SerializeType(message.GetType());
-            var storedMessage = new StoredMessage(content, type, Position: 0, idempotencyKey);
+            var storedMessage = new StoredMessage(content, type, Position: 0, idempotencyKey, Replica: _publisherReplica);
             storedIdAndMessages.Add(new StoredIdAndMessage(storedId,storedMessage));
         }
 
         await _functionStore.MessageStore.AppendMessages(storedIdAndMessages);
-    } 
+    }
 }

--- a/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
@@ -6,7 +6,7 @@ using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.Messaging;
 
-public record StoredMessage(byte[] MessageContent, byte[] MessageType, long Position, string? IdempotencyKey = null, string? Sender = null, string? Receiver = null, ReplicaId? Replica = null)
+public record StoredMessage(byte[] MessageContent, byte[] MessageType, long Position, ReplicaId Replica, string? IdempotencyKey = null, string? Sender = null, string? Receiver = null)
 {
     public object DefaultDeserialize() => JsonSerializer.Deserialize(MessageContent, Type.GetType(MessageType.ToStringFromUtf8Bytes(), throwOnError: true)!)!; //todo remove
 }

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -172,7 +172,7 @@ internal class QueueManager : IDisposable
                 skipPositions = _fetchedPositions.ToList();
 
             var messages = await _messageStore.GetMessages(_storedId, skipPositions);
-            foreach (var (messageContent, messageType, position, idempotencyKey, sender, receiver, _) in messages)
+            foreach (var (messageContent, messageType, position, _, idempotencyKey, sender, receiver) in messages)
             {
                 try
                 {

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -588,7 +588,7 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
             if (!_messages.ContainsKey(storedId))
                 _messages[storedId] = new Dictionary<long, StoredMessage>();
 
-            var owner = _states.TryGetValue(storedId, out var state) ? state.Owner : null;
+            var owner = (_states.TryGetValue(storedId, out var state) ? state.Owner : null) ?? storedMessage.Replica;
             var messages = _messages[storedId];
             messages[_nextMessagePosition++] = storedMessage with { Replica = owner };
 
@@ -613,7 +613,7 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
             if (!_messages.TryGetValue(storedId, out var messages) || !messages.ContainsKey(position))
                 return false.ToTask();
 
-            var owner = _states.TryGetValue(storedId, out var state) ? state.Owner : null;
+            var owner = (_states.TryGetValue(storedId, out var state) ? state.Owner : null) ?? storedMessage.Replica;
             messages[position] = storedMessage with { Replica = owner };
             return true.ToTask();
         }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -69,11 +69,11 @@ public class MariaDbMessageStore : IMessageStore
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = new MySqlCommand(sql, conn);
 
-        foreach (var (messageContent, messageType, _, idempotencyKey, sender, receiver, replica) in messages)
+        foreach (var (messageContent, messageType, _, replica, idempotencyKey, sender, receiver) in messages)
         {
             command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
             command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
-            command.Parameters.Add(new() { Value = replica?.AsGuid.ToString("N") ?? (object)DBNull.Value });
+            command.Parameters.Add(new() { Value = replica.AsGuid.ToString("N") });
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
             command.Parameters.Add(new() { Value = content });
         }
@@ -108,7 +108,7 @@ public class MariaDbMessageStore : IMessageStore
     public async Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
+        var (messageJson, messageType, _, replica, idempotencyKey, sender, receiver) = storedMessage;
 
         _replaceMessageSql ??= @$"
                 UPDATE {_tablePrefix}_messages
@@ -126,7 +126,7 @@ public class MariaDbMessageStore : IMessageStore
             Parameters =
             {
                 new() {Value = storedId.AsGuid.ToString("N")},
-                new() {Value = replica?.AsGuid.ToString("N") ?? (object)DBNull.Value},
+                new() {Value = replica.AsGuid.ToString("N")},
                 new() {Value = content},
                 new() {Value = storedId.AsGuid.ToString("N")},
                 new() {Value = position}
@@ -222,11 +222,11 @@ public class MariaDbMessageStore : IMessageStore
         var storedMessage = new StoredMessage(
             message,
             type,
-            Position: position,
+            position,
+            replica?.ParseToReplicaId() ?? ReplicaId.Empty,
             idempotencyKey?.ToStringFromUtf8Bytes(),
             sender?.ToStringFromUtf8Bytes(),
-            receiver?.ToStringFromUtf8Bytes(),
-            Replica: replica?.ParseToReplicaId()
+            receiver?.ToStringFromUtf8Bytes()
         );
         return storedMessage;
     }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -58,7 +58,7 @@ public class MariaDbMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        var values = messages.Select(_ => $"(?, (SELECT owner FROM {_tablePrefix} WHERE id = ?), ?)").StringJoin(", ");
+        var values = messages.Select(_ => $"(?, COALESCE((SELECT owner FROM {_tablePrefix} WHERE id = ?), ?), ?)").StringJoin(", ");
 
         var sql = @$"
             INSERT INTO {_tablePrefix}_messages
@@ -69,10 +69,11 @@ public class MariaDbMessageStore : IMessageStore
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = new MySqlCommand(sql, conn);
 
-        foreach (var (messageContent, messageType, _, idempotencyKey, sender, receiver, _) in messages)
+        foreach (var (messageContent, messageType, _, idempotencyKey, sender, receiver, replica) in messages)
         {
             command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
             command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
+            command.Parameters.Add(new() { Value = replica?.AsGuid.ToString("N") ?? (object)DBNull.Value });
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
             command.Parameters.Add(new() { Value = content });
         }
@@ -107,11 +108,11 @@ public class MariaDbMessageStore : IMessageStore
     public async Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, _) = storedMessage;
+        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
 
         _replaceMessageSql ??= @$"
                 UPDATE {_tablePrefix}_messages
-                SET replica = (SELECT owner FROM {_tablePrefix} WHERE id = ?), content = ?
+                SET replica = COALESCE((SELECT owner FROM {_tablePrefix} WHERE id = ?), ?), content = ?
                 WHERE id = ? AND position = ?";
         var content = BinaryPacker.Pack(
             messageJson,
@@ -125,6 +126,7 @@ public class MariaDbMessageStore : IMessageStore
             Parameters =
             {
                 new() {Value = storedId.AsGuid.ToString("N")},
+                new() {Value = replica?.AsGuid.ToString("N") ?? (object)DBNull.Value},
                 new() {Value = content},
                 new() {Value = storedId.AsGuid.ToString("N")},
                 new() {Value = position}

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -590,13 +590,14 @@ public class SqlGenerator(string tablePrefix)
             INSERT INTO {tablePrefix}_messages
                 (id, replica, content)
             VALUES
-                 {$"(?, (SELECT owner FROM {tablePrefix} WHERE id = ?), ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
+                 {$"(?, COALESCE((SELECT owner FROM {tablePrefix} WHERE id = ?), ?), ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
 
         var command = StoreCommand.Create(sql);
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, _)) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) in messages)
         {
             command.AddParameter(storedId.AsGuid.ToString("N"));
             command.AddParameter(storedId.AsGuid.ToString("N"));
+            command.AddParameter(replica?.AsGuid.ToString("N") ?? (object)DBNull.Value);
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -593,11 +593,11 @@ public class SqlGenerator(string tablePrefix)
                  {$"(?, COALESCE((SELECT owner FROM {tablePrefix} WHERE id = ?), ?), ?)".Replicate(messages.Count).StringJoin($",{Environment.NewLine}")};";
 
         var command = StoreCommand.Create(sql);
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, replica, idempotencyKey, sender, receiver)) in messages)
         {
             command.AddParameter(storedId.AsGuid.ToString("N"));
             command.AddParameter(storedId.AsGuid.ToString("N"));
-            command.AddParameter(replica?.AsGuid.ToString("N") ?? (object)DBNull.Value);
+            command.AddParameter(replica.AsGuid.ToString("N"));
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -89,10 +89,10 @@ public class PostgreSqlMessageStore : IMessageStore
         await using var conn = await CreateConnection();
         _replaceMessageSql ??= @$"
                 UPDATE {tablePrefix}_messages
-                SET replica = (SELECT owner FROM {tablePrefix} WHERE id = $1), content = $2
-                WHERE id = $1 AND position = $3";
+                SET replica = COALESCE((SELECT owner FROM {tablePrefix} WHERE id = $1), $2), content = $3
+                WHERE id = $1 AND position = $4";
 
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, _) = storedMessage;
+        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
         var content = BinaryPacker.Pack(
             messageJson,
             messageType,
@@ -105,6 +105,7 @@ public class PostgreSqlMessageStore : IMessageStore
             Parameters =
             {
                 new() {Value = storedId.AsGuid},
+                new() {Value = replica?.AsGuid ?? (object)DBNull.Value},
                 new() {Value = content},
                 new() {Value = position},
             }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -92,7 +92,7 @@ public class PostgreSqlMessageStore : IMessageStore
                 SET replica = COALESCE((SELECT owner FROM {tablePrefix} WHERE id = $1), $2), content = $3
                 WHERE id = $1 AND position = $4";
 
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
+        var (messageJson, messageType, _, replica, idempotencyKey, sender, receiver) = storedMessage;
         var content = BinaryPacker.Pack(
             messageJson,
             messageType,
@@ -105,7 +105,7 @@ public class PostgreSqlMessageStore : IMessageStore
             Parameters =
             {
                 new() {Value = storedId.AsGuid},
-                new() {Value = replica?.AsGuid ?? (object)DBNull.Value},
+                new() {Value = replica.AsGuid},
                 new() {Value = content},
                 new() {Value = position},
             }
@@ -190,11 +190,11 @@ public class PostgreSqlMessageStore : IMessageStore
         var storedMessage = new StoredMessage(
             message,
             type,
-            Position: position,
+            position,
+            replica?.ToReplicaId() ?? ReplicaId.Empty,
             idempotencyKey?.ToStringFromUtf8Bytes(),
             sender?.ToStringFromUtf8Bytes(),
-            receiver?.ToStringFromUtf8Bytes(),
-            Replica: replica?.ToReplicaId()
+            receiver?.ToStringFromUtf8Bytes()
         );
         return storedMessage;
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -454,16 +454,18 @@ public class SqlGenerator(string tablePrefix)
     private string? _appendMessagesSql;
     public StoreCommand AppendMessages(StoredId storedId, IEnumerable<StoredMessage> messages)
     {
-        // position is assigned by the table's identity column. unnest($2::bytea[]) WITH ORDINALITY expands the
-        // byte[][] parameter into rows; ORDER BY ord makes the identity assignment follow caller order.
-        // replica is derived from the target flow's current owner.
+        // position is assigned by the table's identity column. unnest($2::bytea[], $3::uuid[]) WITH ORDINALITY
+        // expands the content/fallback-replica parameters into rows in parallel; ORDER BY ord makes the identity
+        // assignment follow caller order. replica is the target flow's current owner, falling back to the
+        // publisher's replica when the target flow is not executing.
         _appendMessagesSql ??= @$"
             INSERT INTO {tablePrefix}_messages (id, replica, content)
-            SELECT $1, (SELECT owner FROM {tablePrefix} WHERE id = $1), content
-            FROM unnest($2::bytea[]) WITH ORDINALITY AS t(content, ord)
+            SELECT $1, COALESCE((SELECT owner FROM {tablePrefix} WHERE id = $1), replica), content
+            FROM unnest($2::bytea[], $3::uuid[]) WITH ORDINALITY AS t(content, replica, ord)
             ORDER BY ord;";
 
-        var contents = messages
+        var materialized = messages.ToList();
+        var contents = materialized
             .Select(m => BinaryPacker.Pack(
                 m.MessageContent,
                 m.MessageType,
@@ -472,12 +474,16 @@ public class SqlGenerator(string tablePrefix)
                 m.Receiver?.ToUtf8Bytes()
             ))
             .ToArray();
+        var replicas = materialized
+            .Select(m => m.Replica?.AsGuid)
+            .ToArray();
 
         return StoreCommand.Create(
             _appendMessagesSql,
             values: [
                 storedId.AsGuid,
-                contents
+                contents,
+                replicas
             ]
         );
     }
@@ -486,24 +492,26 @@ public class SqlGenerator(string tablePrefix)
     // message order.
     public StoreCommand AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
-        // replica is derived from each message's target flow owner. The ordinal column preserves caller order
-        // so the identity column assigns positions accordingly.
+        // replica is each message's target flow owner, falling back to the publisher's replica when the target
+        // flow is not executing. The ordinal column preserves caller order so the identity column assigns
+        // positions accordingly.
         var rows = messages
             .Select((_, i) => i == 0
-                ? $"($1::uuid, $2::bytea, {i})"
-                : $"(${i * 2 + 1}, ${i * 2 + 2}, {i})")
+                ? $"($1::uuid, $2::uuid, $3::bytea, {i})"
+                : $"(${i * 3 + 1}, ${i * 3 + 2}, ${i * 3 + 3}, {i})")
             .StringJoin($",{Environment.NewLine}");
         var sql = @$"
             INSERT INTO {tablePrefix}_messages (id, replica, content)
-            SELECT v.id, (SELECT owner FROM {tablePrefix} WHERE id = v.id), v.content
-            FROM (VALUES {rows}) AS v(id, content, ord)
+            SELECT v.id, COALESCE((SELECT owner FROM {tablePrefix} WHERE id = v.id), v.replica), v.content
+            FROM (VALUES {rows}) AS v(id, replica, content, ord)
             ORDER BY v.ord;";
 
         var command = StoreCommand.Create(sql);
 
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, _)) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) in messages)
         {
             command.AddParameter(storedId.AsGuid);
+            command.AddParameter(replica?.AsGuid ?? (object)DBNull.Value);
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -475,7 +475,7 @@ public class SqlGenerator(string tablePrefix)
             ))
             .ToArray();
         var replicas = materialized
-            .Select(m => m.Replica?.AsGuid)
+            .Select(m => m.Replica.AsGuid)
             .ToArray();
 
         return StoreCommand.Create(
@@ -508,10 +508,10 @@ public class SqlGenerator(string tablePrefix)
 
         var command = StoreCommand.Create(sql);
 
-        foreach (var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) in messages)
+        foreach (var (storedId, (messageContent, messageType, _, replica, idempotencyKey, sender, receiver)) in messages)
         {
             command.AddParameter(storedId.AsGuid);
-            command.AddParameter(replica?.AsGuid ?? (object)DBNull.Value);
+            command.AddParameter(replica.AsGuid);
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,
@@ -609,10 +609,10 @@ public class SqlGenerator(string tablePrefix)
                     contentBytes,
                     typeBytes,
                     position,
+                    replica?.ToReplicaId() ?? ReplicaId.Empty,
                     idempotencyKeyBytes?.ToStringFromUtf8Bytes(),
                     senderBytes?.ToStringFromUtf8Bytes(),
-                    receiverBytes?.ToStringFromUtf8Bytes(),
-                    Replica: replica?.ToReplicaId()
+                    receiverBytes?.ToStringFromUtf8Bytes()
                 )
             );
         }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -585,7 +585,7 @@ public class SqlGenerator(string tablePrefix)
         var appendCommand = StoreCommand.Create(sql);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) = messages[i];
+            var (storedId, (messageContent, messageType, _, replica, idempotencyKey, sender, receiver)) = messages[i];
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,
@@ -594,7 +594,7 @@ public class SqlGenerator(string tablePrefix)
                 receiver?.ToUtf8Bytes()
             );
             appendCommand.AddParameter($"@{prefix}Id{i}", storedId.AsGuid);
-            appendCommand.AddParameter($"@{prefix}Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
+            appendCommand.AddParameter($"@{prefix}Replica{i}", replica.AsGuid);
             appendCommand.AddParameter($"@{prefix}Content{i}", content);
         }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -580,12 +580,12 @@ public class SqlGenerator(string tablePrefix)
             INSERT INTO {tablePrefix}_Messages
                 (Id, Replica, Content)
             VALUES
-                 {messages.Select((_, i) => $"(@{prefix}Id{i}, (SELECT Owner FROM {tablePrefix} WHERE Id = @{prefix}Id{i}), @{prefix}Content{i})").StringJoin($",{Environment.NewLine}")};";
+                 {messages.Select((_, i) => $"(@{prefix}Id{i}, COALESCE((SELECT Owner FROM {tablePrefix} WHERE Id = @{prefix}Id{i}), @{prefix}Replica{i}), @{prefix}Content{i})").StringJoin($",{Environment.NewLine}")};";
 
         var appendCommand = StoreCommand.Create(sql);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, _)) = messages[i];
+            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) = messages[i];
             var content = BinaryPacker.Pack(
                 messageContent,
                 messageType,
@@ -594,6 +594,7 @@ public class SqlGenerator(string tablePrefix)
                 receiver?.ToUtf8Bytes()
             );
             appendCommand.AddParameter($"@{prefix}Id{i}", storedId.AsGuid);
+            appendCommand.AddParameter($"@{prefix}Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
             appendCommand.AddParameter($"@{prefix}Content{i}", content);
         }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -76,9 +76,9 @@ public class SqlServerMessageStore : IMessageStore
 
         for (var i = 0; i < messages.Count; i++)
         {
-            var (messageContent, messageType, _, idempotencyKey, sender, receiver, replica) = messages[i];
+            var (messageContent, messageType, _, replica, idempotencyKey, sender, receiver) = messages[i];
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
-            command.Parameters.AddWithValue($"@Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
+            command.Parameters.AddWithValue($"@Replica{i}", replica.AsGuid);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
 
@@ -119,10 +119,10 @@ public class SqlServerMessageStore : IMessageStore
         await using var command = new SqlCommand(sql, conn);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) = messages[i];
+            var (storedId, (messageContent, messageType, _, replica, idempotencyKey, sender, receiver)) = messages[i];
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
             command.Parameters.AddWithValue($"@Id{i}", storedId.AsGuid);
-            command.Parameters.AddWithValue($"@Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
+            command.Parameters.AddWithValue($"@Replica{i}", replica.AsGuid);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
         foreach (var (value, name) in interuptsSql.Parameters)
@@ -141,7 +141,7 @@ public class SqlServerMessageStore : IMessageStore
             SET Replica = COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), @Replica), Content = @Content
             WHERE Id = @Id AND Position = @Position";
 
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
+        var (messageJson, messageType, _, replica, idempotencyKey, sender, receiver) = storedMessage;
         var content = BinaryPacker.Pack(
             messageJson,
             messageType,
@@ -152,7 +152,7 @@ public class SqlServerMessageStore : IMessageStore
         await using var command = new SqlCommand(_replaceMessageSql, conn);
         command.Parameters.AddWithValue("@Id", storedId.AsGuid);
         command.Parameters.AddWithValue("@Position", position);
-        command.Parameters.AddWithValue("@Replica", replica?.AsGuid ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@Replica", replica.AsGuid);
         command.Parameters.AddWithValue("@Content", content);
         
         var affectedRows = await command.ExecuteNonQueryAsync();
@@ -235,11 +235,11 @@ public class SqlServerMessageStore : IMessageStore
         var storedMessage = new StoredMessage(
             message,
             type,
-            Position: position,
+            position,
+            replica?.ToReplicaId() ?? ReplicaId.Empty,
             idempotencyKey?.ToStringFromUtf8Bytes(),
             sender?.ToStringFromUtf8Bytes(),
-            receiver?.ToStringFromUtf8Bytes(),
-            Replica: replica?.ToReplicaId()
+            receiver?.ToStringFromUtf8Bytes()
         );
         return storedMessage;
     }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -63,7 +63,7 @@ public class SqlServerMessageStore : IMessageStore
         if (messages.Count == 0)
             return;
 
-        var values = messages.Select((_, i) => $"(@Id, (SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), @Content{i})").StringJoin(", ");
+        var values = messages.Select((_, i) => $"(@Id, COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), @Replica{i}), @Content{i})").StringJoin(", ");
 
         var sql = @$"
             INSERT INTO {_tablePrefix}_Messages (Id, Replica, Content)
@@ -76,8 +76,9 @@ public class SqlServerMessageStore : IMessageStore
 
         for (var i = 0; i < messages.Count; i++)
         {
-            var (messageContent, messageType, _, idempotencyKey, sender, receiver, _) = messages[i];
+            var (messageContent, messageType, _, idempotencyKey, sender, receiver, replica) = messages[i];
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
+            command.Parameters.AddWithValue($"@Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
 
@@ -111,16 +112,17 @@ public class SqlServerMessageStore : IMessageStore
             INSERT INTO {_tablePrefix}_Messages
                 (Id, Replica, Content)
             VALUES
-                 {messages.Select((_, i) => $"(@Id{i}, (SELECT Owner FROM {_tablePrefix} WHERE Id = @Id{i}), @Content{i})").StringJoin($",{Environment.NewLine}")};
+                 {messages.Select((_, i) => $"(@Id{i}, COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id{i}), @Replica{i}), @Content{i})").StringJoin($",{Environment.NewLine}")};
 
             {interuptsSql.Sql}";
 
         await using var command = new SqlCommand(sql, conn);
         for (var i = 0; i < messages.Count; i++)
         {
-            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, _)) = messages[i];
+            var (storedId, (messageContent, messageType, _, idempotencyKey, sender, receiver, replica)) = messages[i];
             var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
             command.Parameters.AddWithValue($"@Id{i}", storedId.AsGuid);
+            command.Parameters.AddWithValue($"@Replica{i}", replica?.AsGuid ?? (object)DBNull.Value);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
         foreach (var (value, name) in interuptsSql.Parameters)
@@ -136,10 +138,10 @@ public class SqlServerMessageStore : IMessageStore
 
         _replaceMessageSql ??= @$"
             UPDATE {_tablePrefix}_Messages
-            SET Replica = (SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), Content = @Content
+            SET Replica = COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), @Replica), Content = @Content
             WHERE Id = @Id AND Position = @Position";
 
-        var (messageJson, messageType, _, idempotencyKey, sender, receiver, _) = storedMessage;
+        var (messageJson, messageType, _, idempotencyKey, sender, receiver, replica) = storedMessage;
         var content = BinaryPacker.Pack(
             messageJson,
             messageType,
@@ -150,6 +152,7 @@ public class SqlServerMessageStore : IMessageStore
         await using var command = new SqlCommand(_replaceMessageSql, conn);
         command.Parameters.AddWithValue("@Id", storedId.AsGuid);
         command.Parameters.AddWithValue("@Position", position);
+        command.Parameters.AddWithValue("@Replica", replica?.AsGuid ?? (object)DBNull.Value);
         command.Parameters.AddWithValue("@Content", content);
         
         var affectedRows = await command.ExecuteNonQueryAsync();


### PR DESCRIPTION
Follow-up to #160.

## Summary
Refines how a message's `replica` is resolved and makes it a guaranteed non-null value:

```
replica = COALESCE(target flow's current owner, publishing replica)
```

The target flow's current owner (`StoredFlow.OwnerId`) still wins; when that flow isn't executing, the message records the **publishing replica's own id** instead of `null`. `StoredMessage.Replica` is now a non-null `ReplicaId` (absent ⇒ `ReplicaId.Empty`).

## Changes
**Publisher replica (carried on the message)**
- `MessageWriter.publisherReplica` is required and non-null; `MessageWriters` carries the registry's `ClusterInfo.ReplicaId`. In-flow publishing uses the executing flow's replica; external `SendMessage`/batched sends use the registry replica; `InvocationHelper` completion + initial messages use `_replicaId`.

**`StoredMessage.Replica` → required non-null positional parameter**
- Moved to the 4th positional parameter (after `Position`), type `ReplicaId` (no default). All `new StoredMessage(...)` call sites and deconstructions updated.

**Stores**
- `replica` resolved in-statement via `COALESCE(<flows-table owner subselect>, <message replica>)` on insert and replace:
  - PostgreSQL: `COALESCE((SELECT owner …), replica)` in the `unnest` SELECT and the `VALUES`-derived bulk SELECT.
  - SqlServer / MariaDB: `COALESCE((SELECT owner …), @Replica/?)` in the `VALUES` tuples and `UPDATE`.
  - In-memory: `target owner ?? message.Replica`.
- The publisher replica is always non-null and `COALESCE` is always non-null, so the column never receives null for new rows; the read path coerces any legacy `NULL` row to `ReplicaId.Empty`.

## Testing
- Build clean (0/0).
- `MessageReplicaIsTakenFromTargetFlowOwner` covers executing→owner, idle+publisher→publisher, idle+empty→`ReplicaId.Empty`, across single/bulk/multi-id/replace — passes on in-memory + PostgreSQL + SqlServer + MariaDB (27 each).
- In-memory: 145 tests pass (Messaging + StoreTests + StoreCrudTests + ControlPanelTests + MessageBatcher).
- PostgreSQL `StoreCrudTests` (create-with-initial-messages path): 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)