### PR TITLE
Add MessageWatchdog (pull messages, push to live flows) — iteration 1

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowState.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Helpers;
+using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Queuing;
 using Cleipnir.ResilientFunctions.Storage;
 
@@ -97,6 +99,12 @@ public class FlowState
     {
         if (Suspended) return;
         QueueManager?.Interrupt();
+    }
+
+    public Task Push(IReadOnlyList<StoredMessage> messages)
+    {
+        if (Suspended) return Task.CompletedTask;
+        return QueueManager?.Push(messages) ?? Task.CompletedTask;
     }
 
     public bool Suspend()

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Messaging;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime;
@@ -36,6 +37,17 @@ public class FlowsManager
             foreach (var id in ids)
                 if (_dict.TryGetValue(id, out var flowState))
                     flowState.Interrupt();
+    }
+
+    public Task Push(IReadOnlyDictionary<StoredId, List<StoredMessage>> messagesByFlow)
+    {
+        List<Task> tasks = new();
+        lock (_lock)
+            foreach (var (id, messages) in messagesByFlow)
+                if (_dict.TryGetValue(id, out var flowState))
+                    tasks.Add(flowState.Push(messages));
+
+        return Task.WhenAll(tasks);
     }
 
     /*

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Domain;
+using Cleipnir.ResilientFunctions.Domain.Exceptions;
+using Cleipnir.ResilientFunctions.Helpers;
+using Cleipnir.ResilientFunctions.Messaging;
+
+namespace Cleipnir.ResilientFunctions.CoreRuntime.Watchdogs;
+
+internal class MessageWatchdog
+{
+    private readonly IMessageStore _messageStore;
+    private readonly FlowsManager _flowsManager;
+    private readonly ClusterInfo _clusterInfo;
+    private readonly ShutdownCoordinator _shutdownCoordinator;
+    private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
+    private readonly TimeSpan _checkFrequency;
+    private readonly TimeSpan _delayStartUp;
+    private readonly UtcNow _utcNow;
+
+    public MessageWatchdog(
+        IMessageStore messageStore,
+        FlowsManager flowsManager,
+        ClusterInfo clusterInfo,
+        ShutdownCoordinator shutdownCoordinator,
+        UnhandledExceptionHandler unhandledExceptionHandler,
+        TimeSpan checkFrequency,
+        TimeSpan delayStartUp,
+        UtcNow utcNow)
+    {
+        _messageStore = messageStore;
+        _flowsManager = flowsManager;
+        _clusterInfo = clusterInfo;
+        _shutdownCoordinator = shutdownCoordinator;
+        _unhandledExceptionHandler = unhandledExceptionHandler;
+        _checkFrequency = checkFrequency;
+        _delayStartUp = delayStartUp;
+        _utcNow = utcNow;
+    }
+
+    public async Task Start()
+    {
+        await Task.Delay(_delayStartUp);
+
+        Start:
+        try
+        {
+            while (!_shutdownCoordinator.ShutdownInitiated)
+            {
+                var now = _utcNow();
+
+                // Messages destined for flows currently owned by this replica (replica = COALESCE(owner, publisher)).
+                // FlowsManager.Push delivers only to live flows; entries for non-live flows are ignored.
+                var messagesByFlow = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId);
+                if (messagesByFlow.Count > 0)
+                    await _flowsManager.Push(messagesByFlow);
+
+                var timeElapsed = _utcNow() - now;
+                var delay = (_checkFrequency - timeElapsed).RoundUpToZero();
+
+                await Task.Delay(delay);
+            }
+        }
+        catch (Exception thrownException)
+        {
+            _unhandledExceptionHandler.Invoke(
+                new FrameworkException(
+                    $"{nameof(MessageWatchdog)} execution failed - retrying in 5 seconds",
+                    innerException: thrownException
+                )
+            );
+
+            await Task.Delay(5_000);
+            goto Start;
+        }
+    }
+}

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -32,6 +32,7 @@ public class FunctionsRegistry : IDisposable
     private readonly Lock _sync = new();
     private readonly ReplicaWatchdog _replicaWatchdog;
     private readonly InterruptedWatchdog _interruptedWatchdog;
+    private readonly MessageWatchdog _messageWatchdog;
     private readonly FlowsManager _flowsManager;
 
     public FunctionsRegistry(IFunctionStore functionStore, Settings? settings = null)
@@ -73,11 +74,23 @@ public class FunctionsRegistry : IDisposable
             utcNow
         );
 
+        _messageWatchdog = new MessageWatchdog(
+            _functionStore.MessageStore,
+            _flowsManager,
+            ClusterInfo,
+            _shutdownCoordinator,
+            _settings.UnhandledExceptionHandler,
+            _settings.WatchdogCheckFrequency,
+            _settings.DelayStartup,
+            utcNow
+        );
+
         if (_settings.EnableWatchdogs)
         {
             _replicaWatchdog.Initialize().GetAwaiter().GetResult();
             _ = _replicaWatchdog.Start();
             _ = Task.Run(_interruptedWatchdog.Start);
+            _ = Task.Run(_messageWatchdog.Start);
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.Messaging;
@@ -19,4 +20,10 @@ public interface IMessageStore
     Task<IReadOnlyList<StoredMessage>> GetMessages(StoredId storedId);
     Task<IReadOnlyList<StoredMessage>> GetMessages(StoredId storedId, IReadOnlyList<long> skipPositions);
     Task<Dictionary<StoredId, List<StoredMessage>>> GetMessages(IEnumerable<StoredId> storedIds);
+
+    /// <summary>
+    /// Returns the undelivered messages whose replica equals the provided replica, grouped by target flow.
+    /// Used by the MessageWatchdog to push messages to live flows owned by this replica.
+    /// </summary>
+    Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId);
 }

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -117,6 +117,30 @@ internal class QueueManager : IDisposable
         _ = FetchMessagesOnce();
     }
 
+    /// <summary>
+    /// Pushes messages fetched elsewhere (the MessageWatchdog) straight into the delivery pipeline,
+    /// avoiding a per-flow re-fetch. Idempotent: positions already processed are skipped by ProcessMessages.
+    /// </summary>
+    public async Task Push(IReadOnlyList<StoredMessage> messages)
+    {
+        if (_disposed || messages.Count == 0)
+            return;
+
+        await _fetchSemaphore.WaitAsync();
+        try
+        {
+            if (_thrownException != null)
+                return;
+
+            await ProcessMessages(messages);
+        }
+        finally
+        {
+            DeliverMessages();
+            _fetchSemaphore.Release();
+        }
+    }
+
     public async Task<Envelope?> Subscribe(
         MessagePredicate predicate,
         DateTime? timeout,
@@ -172,46 +196,59 @@ internal class QueueManager : IDisposable
                 skipPositions = _fetchedPositions.ToList();
 
             var messages = await _messageStore.GetMessages(_storedId, skipPositions);
-            foreach (var (messageContent, messageType, position, _, idempotencyKey, sender, receiver) in messages)
-            {
-                try
-                {
-                    var msg = _serializer.Deserialize(messageContent, _serializer.ResolveType(messageType)!);
-
-                    if (idempotencyKey != null && !_idempotencyKeys.Add(idempotencyKey, position))
-                    {
-                        await _messageStore.DeleteMessages(_storedId, [position]);
-                        continue;
-                    }
-
-                    var envelope = new Envelope(msg, receiver, sender);
-                    var messageData = new MessageData(
-                        envelope,
-                        position,
-                        messageContent,
-                        messageType,
-                        receiver,
-                        sender
-                    );
-                    lock (_lock)
-                    {
-                        _toDeliver.Add(messageData);
-                        _fetchedPositions.Add(position);
-                    }
-                }
-                catch (Exception e)
-                {
-                    _unhandledExceptionHandler.Invoke(_flowId.Type, e);
-                    _thrownException = e;
-                    FailAllSubscriptions(e);
-                    return;
-                }
-            }
+            await ProcessMessages(messages);
         }
         finally
         {
             DeliverMessages();
             _fetchSemaphore.Release();
+        }
+    }
+
+    // Caller must hold _fetchSemaphore. Deserializes, dedups by idempotency-key and by already-fetched
+    // position (so pushes are idempotent), and stages messages for delivery.
+    private async Task ProcessMessages(IReadOnlyList<StoredMessage> messages)
+    {
+        foreach (var (messageContent, messageType, position, _, idempotencyKey, sender, receiver) in messages)
+        {
+            bool alreadyFetched;
+            lock (_lock)
+                alreadyFetched = _fetchedPositions.Contains(position);
+            if (alreadyFetched)
+                continue;
+
+            try
+            {
+                var msg = _serializer.Deserialize(messageContent, _serializer.ResolveType(messageType)!);
+
+                if (idempotencyKey != null && !_idempotencyKeys.Add(idempotencyKey, position))
+                {
+                    await _messageStore.DeleteMessages(_storedId, [position]);
+                    continue;
+                }
+
+                var envelope = new Envelope(msg, receiver, sender);
+                var messageData = new MessageData(
+                    envelope,
+                    position,
+                    messageContent,
+                    messageType,
+                    receiver,
+                    sender
+                );
+                lock (_lock)
+                {
+                    _toDeliver.Add(messageData);
+                    _fetchedPositions.Add(position);
+                }
+            }
+            catch (Exception e)
+            {
+                _unhandledExceptionHandler.Invoke(_flowId.Type, e);
+                _thrownException = e;
+                FailAllSubscriptions(e);
+                return;
+            }
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -667,5 +667,25 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         return dict;
     }
 
+    public Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    {
+        lock (_sync)
+        {
+            var dict = new Dictionary<StoredId, List<StoredMessage>>();
+            foreach (var (storedId, messages) in _messages)
+            {
+                var list = messages
+                    .OrderBy(kv => kv.Key)
+                    .Where(kv => kv.Value.Replica == replicaId)
+                    .Select(kv => kv.Value with { Position = kv.Key })
+                    .ToList();
+                if (list.Count > 0)
+                    dict[storedId] = list;
+            }
+
+            return dict.ToTask();
+        }
+    }
+
     #endregion
 }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -211,6 +211,26 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    {
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var command = _sqlGenerator
+            .GetMessagesForReplica(replicaId)
+            .ToSqlCommand(conn);
+
+        await using var reader = await command.ExecuteReaderAsync();
+
+        var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
+        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+
+        foreach (var id in messages.Keys)
+            storedMessages[id] = messages[id]
+                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
+                .ToList();
+
+        return storedMessages;
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, string? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -660,6 +660,17 @@ public class SqlGenerator(string tablePrefix)
         return messages;
     }
 
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    {
+        var sql = @$"
+            SELECT id, position, content, replica
+            FROM {tablePrefix}_messages
+            WHERE replica = ?
+            ORDER BY position;";
+
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N") ]);
+    }
+
     public StoreCommand GetMessages(IEnumerable<StoredId> storedIds)
     {
         var sql = @$"

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -179,6 +179,22 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    {
+        await using var conn = await CreateConnection();
+        await using var command = sqlGenerator.GetMessagesForReplica(replicaId).ToNpgsqlCommand(conn);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        var messages = await sqlGenerator.ReadStoredIdsMessages(reader);
+        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        foreach (var id in messages.Keys)
+            storedMessages[id] = messages[id]
+                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
+                .ToList();
+
+        return storedMessages;
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, Guid? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -583,6 +583,17 @@ public class SqlGenerator(string tablePrefix)
         var storeCommand = StoreCommand.Create(sql, values: [ storedIds.Select(id => id.AsGuid).ToArray() ]);
         return storeCommand;
     }
+
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    {
+        var sql = @$"
+            SELECT id, position, content, replica
+            FROM {tablePrefix}_messages
+            WHERE replica = $1
+            ORDER BY position;";
+
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid ]);
+    }
     
     public async Task<Dictionary<StoredId, IReadOnlyList<StoredMessage>>> ReadMessagesForMultipleStores(NpgsqlDataReader reader)
     {

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -661,6 +661,20 @@ public class SqlGenerator(string tablePrefix)
         return command;
     }
 
+    private string? _getMessagesForReplicaSql;
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    {
+        _getMessagesForReplicaSql ??= @$"
+            SELECT Id, Position, Content, Replica
+            FROM {tablePrefix}_Messages
+            WHERE Replica = @Replica
+            ORDER BY Position;";
+
+        var command = StoreCommand.Create(_getMessagesForReplicaSql);
+        command.AddParameter("@Replica", replicaId.AsGuid);
+        return command;
+    }
+
     public async Task<Dictionary<StoredId, List<(byte[] content, long position, Guid? replica)>>> ReadStoredIdsMessages(SqlDataReader reader)
     {
         var messages = new Dictionary<StoredId, List<(byte[] content, long position, Guid? replica)>>();

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -224,6 +224,22 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    {
+        await using var conn = await CreateConnection();
+        await using var cmd = _sqlGenerator.GetMessagesForReplica(replicaId).ToSqlCommand(conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
+        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        foreach (var id in messages.Keys)
+            storedMessages[id] = messages[id]
+                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
+                .ToList();
+
+        return storedMessages;
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, Guid? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);


### PR DESCRIPTION
First iteration toward a message-driven wake-up mechanism. Deliberately minimal — more iterations to follow.

## Summary
Adds a per-replica **MessageWatchdog** that periodically pulls undelivered messages addressed to this replica and pushes them straight into the owning live flows' `QueueManager`s, avoiding a per-flow re-fetch. It uses the `replica` column on messages (added in #160/#161) as the routing key.

## Changes
- **`IMessageStore.GetMessagesForReplica(ReplicaId)`** — returns undelivered messages grouped by target flow `WHERE replica = @me`. Implemented in InMemory + PostgreSQL + SqlServer + MariaDB (reusing the existing multi-id readers).
- **`QueueManager`** — extracted the per-message processing body of `FetchAndNotify` into `ProcessMessages` (with an in-memory fetched-position skip, so push is idempotent) and added a `Push(messages)` entrypoint. Message deletion on delivery is unchanged.
- **`FlowsManager.Push` / `FlowState.Push`** — route pushed messages to live flows only.
- **`MessageWatchdog`** — modeled on the existing watchdog loop; pulls `GetMessagesForReplica` and pushes to owned live flows each `WatchdogCheckFrequency`.
- Wired into `FunctionsRegistry`, running **alongside** the existing `InterruptedWatchdog` for now.

## Deliberately out of scope (future iterations)
- No changes to `IFunctionStore`, suspend/postpone, or the `interrupted` column/watchdog — those stay exactly as-is for now.
- The eventual goal (remove the InterruptedWatchdog and the interrupt-flag wake-up) is left for later iterations.

## Testing
- Full solution builds clean (0/0).
- In-memory Messaging suite: 56/56 (also verified passing with the InterruptedWatchdog disabled, i.e. delivery via the MessageWatchdog alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)