### PR TITLE
Add GetCrashedReplicaMessages and SetReplica to IMessageStore

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
@@ -117,4 +117,12 @@ public class MessageStoreTests :  TestTemplates.MessageStoreTests
     [TestMethod]
     public override Task MessageReplicaIsTakenFromTargetFlowOwner()
         => MessageReplicaIsTakenFromTargetFlowOwner(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task CrashedReplicaMessagesAreFetched()
+        => CrashedReplicaMessagesAreFetched(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task MessageReplicaCanBeReassigned()
+        => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1203,4 +1203,70 @@ public abstract class MessageStoreTests
         var afterReplaceIdle = (await messageStore.GetMessages(idleFlow)).ToList();
         afterReplaceIdle.Single(m => m.Position == idleMessages[1].Position).Replica.ShouldBe(publisher);
     }
+
+    public abstract Task CrashedReplicaMessagesAreFetched();
+    protected async Task CrashedReplicaMessagesAreFetched(Task<IFunctionStore> functionStoreTask)
+    {
+        var functionStore = await functionStoreTask;
+        var messageStore = functionStore.MessageStore;
+        var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
+
+        var liveReplica = ReplicaId.NewId();
+        var crashedReplica1 = ReplicaId.NewId();
+        var crashedReplica2 = ReplicaId.NewId();
+
+        var flow1 = TestStoredId.Create();
+        var flow2 = TestStoredId.Create();
+
+        // owned by a live replica -> not crashed
+        await messageStore.AppendMessage(flow1, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: liveReplica));
+        // owned by crashed replicas -> crashed
+        await messageStore.AppendMessage(flow1, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: crashedReplica1));
+        await messageStore.AppendMessage(flow2, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: crashedReplica2));
+
+        var flow1Messages = await messageStore.GetMessages(flow1);
+        var flow2Messages = await messageStore.GetMessages(flow2);
+        var bPosition = flow1Messages.Single(m => m.Replica == crashedReplica1).Position;
+        var cPosition = flow2Messages.Single(m => m.Replica == crashedReplica2).Position;
+
+        var crashed = await messageStore.GetCrashedReplicaMessages([liveReplica]);
+
+        crashed.Count.ShouldBe(2);
+        crashed.ShouldContain(t => t.Item1 == flow1 && t.Item2 == bPosition);
+        crashed.ShouldContain(t => t.Item1 == flow2 && t.Item2 == cPosition);
+    }
+
+    public abstract Task MessageReplicaCanBeReassigned();
+    protected async Task MessageReplicaCanBeReassigned(Task<IFunctionStore> functionStoreTask)
+    {
+        var functionStore = await functionStoreTask;
+        var messageStore = functionStore.MessageStore;
+        var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
+
+        var crashedReplica = ReplicaId.NewId();
+        var newReplica = ReplicaId.NewId();
+        var otherReplica = ReplicaId.NewId();
+
+        var flow1 = TestStoredId.Create();
+        var flow2 = TestStoredId.Create();
+
+        await messageStore.AppendMessage(flow1, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: crashedReplica));
+        await messageStore.AppendMessage(flow2, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: crashedReplica));
+        // owned by a different replica -> must not be reassigned even though its position is included
+        await messageStore.AppendMessage(flow2, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: otherReplica));
+
+        var aPosition = (await messageStore.GetMessages(flow1)).Single().Position;
+        var flow2Messages = await messageStore.GetMessages(flow2);
+        var bPosition = flow2Messages.Single(m => m.Replica == crashedReplica).Position;
+        var cPosition = flow2Messages.Single(m => m.Replica == otherReplica).Position;
+
+        await messageStore.SetReplica([aPosition, bPosition, cPosition], newReplica, expectedReplica: crashedReplica);
+
+        var afterFlow1 = await messageStore.GetMessages(flow1);
+        var afterFlow2 = await messageStore.GetMessages(flow2);
+
+        afterFlow1.Single().Replica.ShouldBe(newReplica);
+        afterFlow2.Single(m => m.Position == bPosition).Replica.ShouldBe(newReplica);
+        afterFlow2.Single(m => m.Position == cPosition).Replica.ShouldBe(otherReplica);
+    }
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1229,7 +1229,7 @@ public abstract class MessageStoreTests
         var bPosition = flow1Messages.Single(m => m.Replica == crashedReplica1).Position;
         var cPosition = flow2Messages.Single(m => m.Replica == crashedReplica2).Position;
 
-        var crashed = await messageStore.GetCrashedReplicaMessages([liveReplica]);
+        var crashed = await messageStore.GetCrashedReplicaMessages(new HashSet<ReplicaId> { liveReplica });
 
         crashed.Count.ShouldBe(2);
         crashed.ShouldContain(t => t.StoredId == flow1 && t.Position == bPosition);

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1232,8 +1232,8 @@ public abstract class MessageStoreTests
         var crashed = await messageStore.GetCrashedReplicaMessages([liveReplica]);
 
         crashed.Count.ShouldBe(2);
-        crashed.ShouldContain(t => t.Item1 == flow1 && t.Item2 == bPosition);
-        crashed.ShouldContain(t => t.Item1 == flow2 && t.Item2 == cPosition);
+        crashed.ShouldContain(t => t.StoredId == flow1 && t.Position == bPosition);
+        crashed.ShouldContain(t => t.StoredId == flow2 && t.Position == cPosition);
     }
 
     public abstract Task MessageReplicaCanBeReassigned();

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -37,7 +37,7 @@ public interface IMessageStore
     /// longer alive (its replica is not contained in <paramref name="liveReplicas"/>).
     /// Used to detect messages stranded by crashed replicas so they can be re-assigned to a live replica via <see cref="SetReplica"/>.
     /// </summary>
-    Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas);
+    Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas);
 
     /// <summary>
     /// Re-assigns the messages at the provided positions to <paramref name="newReplica"/>,

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Storage;
@@ -38,7 +37,7 @@ public interface IMessageStore
     /// longer alive (its replica is not contained in <paramref name="liveReplicas"/>).
     /// Used to detect messages stranded by crashed replicas so they can be re-assigned to a live replica via <see cref="SetReplica"/>.
     /// </summary>
-    Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas);
+    Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas);
 
     /// <summary>
     /// Re-assigns the messages at the provided positions to <paramref name="newReplica"/>,

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Storage;
@@ -31,4 +32,17 @@ public interface IMessageStore
     /// Used by the MessageWatchdog to push messages to live flows owned by this replica.
     /// </summary>
     Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId);
+
+    /// <summary>
+    /// Returns the (flow, position) identifiers of the undelivered messages owned by a replica that is no
+    /// longer alive (its replica is not contained in <paramref name="liveReplicas"/>).
+    /// Used to detect messages stranded by crashed replicas so they can be re-assigned to a live replica via <see cref="SetReplica"/>.
+    /// </summary>
+    Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas);
+
+    /// <summary>
+    /// Re-assigns the messages at the provided positions to <paramref name="newReplica"/>,
+    /// but only those still owned by <paramref name="expectedReplica"/>.
+    /// </summary>
+    Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica);
 }

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -688,5 +688,33 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         }
     }
 
+    public Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        var live = liveReplicas.ToHashSet();
+        lock (_sync)
+        {
+            var result = new List<Tuple<StoredId, long>>();
+            foreach (var (storedId, messages) in _messages)
+                foreach (var (position, message) in messages.OrderBy(kv => kv.Key))
+                    if (!live.Contains(message.Replica))
+                        result.Add(Tuple.Create(storedId, position));
+
+            return result.ToTask();
+        }
+    }
+
+    public Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        lock (_sync)
+        {
+            foreach (var position in positions)
+                foreach (var messages in _messages.Values)
+                    if (messages.TryGetValue(position, out var message) && message.Replica == expectedReplica)
+                        messages[position] = message with { Replica = newReplica };
+
+            return Task.CompletedTask;
+        }
+    }
+
     #endregion
 }

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -688,15 +688,14 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         }
     }
 
-    public Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
-        var live = liveReplicas.ToHashSet();
         lock (_sync)
         {
             var result = new List<StoredIdAndPosition>();
             foreach (var (storedId, messages) in _messages)
                 foreach (var (position, message) in messages.OrderBy(kv => kv.Key))
-                    if (!live.Contains(message.Replica))
+                    if (!liveReplicas.Contains(message.Replica))
                         result.Add(new StoredIdAndPosition(storedId, position));
 
             return result.ToTask();

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -688,16 +688,16 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         }
     }
 
-    public Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         var live = liveReplicas.ToHashSet();
         lock (_sync)
         {
-            var result = new List<Tuple<StoredId, long>>();
+            var result = new List<StoredIdAndPosition>();
             foreach (var (storedId, messages) in _messages)
                 foreach (var (position, message) in messages.OrderBy(kv => kv.Key))
                     if (!live.Contains(message.Replica))
-                        result.Add(Tuple.Create(storedId, position));
+                        result.Add(new StoredIdAndPosition(storedId, position));
 
             return result.ToTask();
         }

--- a/Core/Cleipnir.ResilientFunctions/Storage/Types.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/Types.cs
@@ -113,6 +113,8 @@ public record StoredException(string ExceptionMessage, string? ExceptionStackTra
 
 public record StatusAndId(StoredId StoredId, Status Status, long Expiry);
 
+public record StoredIdAndPosition(StoredId StoredId, long Position);
+
 public record StoredEffectChange(
     StoredId StoredId,
     EffectId EffectId,

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
@@ -112,4 +112,12 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaIsTakenFromTargetFlowOwner()
         => MessageReplicaIsTakenFromTargetFlowOwner(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task CrashedReplicaMessagesAreFetched()
+        => CrashedReplicaMessagesAreFetched(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task MessageReplicaCanBeReassigned()
+        => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
 }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -30,7 +30,7 @@ public class MariaDbMessageStore : IMessageStore
             CREATE TABLE IF NOT EXISTS {_tablePrefix}_messages (
                 position BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                 id CHAR(32),
-                replica CHAR(32) NULL,
+                replica CHAR(32) NOT NULL,
                 content LONGBLOB,
                 INDEX {_tablePrefix}_messages_id_idx (id)
             );";

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -212,6 +212,30 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var command = _sqlGenerator
+            .GetCrashedReplicaMessages(liveReplicas)
+            .ToSqlCommand(conn);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        return await _sqlGenerator.ReadStoredIdAndPositions(reader);
+    }
+
+    public async Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var positionsList = positions.ToList();
+        if (positionsList.Count == 0)
+            return;
+
+        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
+        await using var command = _sqlGenerator
+            .SetReplica(positionsList, newReplica, expectedReplica)
+            .ToSqlCommand(conn);
+        await command.ExecuteNonQueryAsync();
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, string? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -212,7 +212,7 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = _sqlGenerator

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -212,7 +212,7 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = _sqlGenerator

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using Cleipnir.ResilientFunctions.Domain;
@@ -687,14 +686,14 @@ public class SqlGenerator(string tablePrefix)
         return StoreCommand.Create(sql);
     }
 
-    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(MySqlDataReader reader)
+    public async Task<List<StoredIdAndPosition>> ReadStoredIdAndPositions(MySqlDataReader reader)
     {
-        var result = new List<Tuple<StoredId, long>>();
+        var result = new List<StoredIdAndPosition>();
         while (await reader.ReadAsync())
         {
             var id = reader.GetString(0).ToGuid().ToStoredId();
             var position = reader.GetInt64(1);
-            result.Add(Tuple.Create(id, position));
+            result.Add(new StoredIdAndPosition(id, position));
         }
 
         return result;

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -671,7 +671,7 @@ public class SqlGenerator(string tablePrefix)
         return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N") ]);
     }
 
-    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         var replicas = liveReplicas.Select(r => $"'{r.AsGuid:N}'").ToList();
         var sql = @$"

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using Cleipnir.ResilientFunctions.Domain;
@@ -669,6 +670,52 @@ public class SqlGenerator(string tablePrefix)
             ORDER BY position;";
 
         return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N") ]);
+    }
+
+    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        var replicas = liveReplicas.Select(r => $"'{r.AsGuid:N}'").ToList();
+        var notInClause = replicas.Count == 0
+            ? ""
+            : $" AND replica NOT IN ({replicas.StringJoin(", ")})";
+        var sql = @$"
+            SELECT id, position
+            FROM {tablePrefix}_messages
+            WHERE replica IS NOT NULL{notInClause}
+            ORDER BY position;";
+
+        return StoreCommand.Create(sql);
+    }
+
+    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(MySqlDataReader reader)
+    {
+        var result = new List<Tuple<StoredId, long>>();
+        while (await reader.ReadAsync())
+        {
+            var id = reader.GetString(0).ToGuid().ToStoredId();
+            var position = reader.GetInt64(1);
+            result.Add(Tuple.Create(id, position));
+        }
+
+        return result;
+    }
+
+    public StoreCommand SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var positionsList = positions.ToList();
+
+        var sql = @$"
+                UPDATE {tablePrefix}_messages
+                SET replica = ?
+                WHERE position IN ({string.Join(", ", positionsList.Select(_ => "?"))}) AND replica = ?";
+
+        var command = StoreCommand.Create(sql);
+        command.AddParameter(newReplica.AsGuid.ToString("N"));
+        foreach (var position in positionsList)
+            command.AddParameter(position);
+        command.AddParameter(expectedReplica.AsGuid.ToString("N"));
+
+        return command;
     }
 
     public StoreCommand GetMessages(IEnumerable<StoredId> storedIds)

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -674,14 +674,10 @@ public class SqlGenerator(string tablePrefix)
     public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         var replicas = liveReplicas.Select(r => $"'{r.AsGuid:N}'").ToList();
-        var notInClause = replicas.Count == 0
-            ? ""
-            : $" AND replica NOT IN ({replicas.StringJoin(", ")})";
         var sql = @$"
             SELECT id, position
             FROM {tablePrefix}_messages
-            WHERE replica IS NOT NULL{notInClause}
-            ORDER BY position;";
+            WHERE replica NOT IN ({replicas.StringJoin(", ")})";
 
         return StoreCommand.Create(sql);
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
@@ -113,4 +113,12 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaIsTakenFromTargetFlowOwner()
         => MessageReplicaIsTakenFromTargetFlowOwner(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task CrashedReplicaMessagesAreFetched()
+        => CrashedReplicaMessagesAreFetched(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task MessageReplicaCanBeReassigned()
+        => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
 }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -211,7 +211,7 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         await using var conn = await CreateConnection();
         await using var command = sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToNpgsqlCommand(conn);

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -211,7 +211,7 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         await using var conn = await CreateConnection();
         await using var command = sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToNpgsqlCommand(conn);

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -39,7 +39,7 @@ public class PostgreSqlMessageStore : IMessageStore
             CREATE TABLE IF NOT EXISTS {tablePrefix}_messages (
                 position BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 id UUID,
-                replica UUID NULL,
+                replica UUID NOT NULL,
                 content BYTEA
             );
             CREATE INDEX IF NOT EXISTS {tablePrefix}_messages_id_idx ON {tablePrefix}_messages (id);";

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -211,6 +211,26 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        await using var conn = await CreateConnection();
+        await using var command = sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToNpgsqlCommand(conn);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        return await sqlGenerator.ReadStoredIdAndPositions(reader);
+    }
+
+    public async Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var positionsArray = positions.ToArray();
+        if (positionsArray.Length == 0)
+            return;
+
+        await using var conn = await CreateConnection();
+        await using var command = sqlGenerator.SetReplica(positionsArray, newReplica, expectedReplica).ToNpgsqlCommand(conn);
+        await command.ExecuteNonQueryAsync();
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, Guid? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -606,14 +606,14 @@ public class SqlGenerator(string tablePrefix)
         return StoreCommand.Create(sql, values: [ liveReplicas.Select(r => r.AsGuid).ToArray() ]);
     }
 
-    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(NpgsqlDataReader reader)
+    public async Task<List<StoredIdAndPosition>> ReadStoredIdAndPositions(NpgsqlDataReader reader)
     {
-        var result = new List<Tuple<StoredId, long>>();
+        var result = new List<StoredIdAndPosition>();
         while (await reader.ReadAsync())
         {
             var id = reader.GetGuid(0).ToStoredId();
             var position = reader.GetInt64(1);
-            result.Add(Tuple.Create(id, position));
+            result.Add(new StoredIdAndPosition(id, position));
         }
 
         return result;

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -595,7 +595,7 @@ public class SqlGenerator(string tablePrefix)
         return StoreCommand.Create(sql, values: [ replicaId.AsGuid ]);
     }
 
-    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         var sql = @$"
             SELECT id, position

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -600,8 +600,7 @@ public class SqlGenerator(string tablePrefix)
         var sql = @$"
             SELECT id, position
             FROM {tablePrefix}_messages
-            WHERE replica IS NOT NULL AND replica != ALL($1)
-            ORDER BY position;";
+            WHERE replica != ALL($1)";
 
         return StoreCommand.Create(sql, values: [ liveReplicas.Select(r => r.AsGuid).ToArray() ]);
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -594,6 +594,43 @@ public class SqlGenerator(string tablePrefix)
 
         return StoreCommand.Create(sql, values: [ replicaId.AsGuid ]);
     }
+
+    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        var sql = @$"
+            SELECT id, position
+            FROM {tablePrefix}_messages
+            WHERE replica IS NOT NULL AND replica != ALL($1)
+            ORDER BY position;";
+
+        return StoreCommand.Create(sql, values: [ liveReplicas.Select(r => r.AsGuid).ToArray() ]);
+    }
+
+    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(NpgsqlDataReader reader)
+    {
+        var result = new List<Tuple<StoredId, long>>();
+        while (await reader.ReadAsync())
+        {
+            var id = reader.GetGuid(0).ToStoredId();
+            var position = reader.GetInt64(1);
+            result.Add(Tuple.Create(id, position));
+        }
+
+        return result;
+    }
+
+    public StoreCommand SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var sql = @$"
+            UPDATE {tablePrefix}_messages
+            SET replica = $1
+            WHERE position = ANY($2) AND replica = $3";
+
+        return StoreCommand.Create(
+            sql,
+            values: [ newReplica.AsGuid, positions.ToArray(), expectedReplica.AsGuid ]
+        );
+    }
     
     public async Task<Dictionary<StoredId, IReadOnlyList<StoredMessage>>> ReadMessagesForMultipleStores(NpgsqlDataReader reader)
     {

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
@@ -113,4 +113,12 @@ public class MessageStoreTests :  Cleipnir.ResilientFunctions.Tests.Messaging.Te
     [TestMethod]
     public override Task MessageReplicaIsTakenFromTargetFlowOwner()
         => MessageReplicaIsTakenFromTargetFlowOwner(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task CrashedReplicaMessagesAreFetched()
+        => CrashedReplicaMessagesAreFetched(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task MessageReplicaCanBeReassigned()
+        => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
 }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -675,7 +675,7 @@ public class SqlGenerator(string tablePrefix)
         return command;
     }
 
-    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         var replicas = liveReplicas.ToList();
         var sql = @$"

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -677,15 +677,13 @@ public class SqlGenerator(string tablePrefix)
 
     public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
-        var replicas = liveReplicas.ToList();
         var sql = @$"
             SELECT Id, Position
             FROM {tablePrefix}_Messages
-            WHERE Replica NOT IN ({replicas.Select((_, i) => $"@Replica{i}").StringJoin(", ")})";
+            WHERE Replica NOT IN (SELECT CAST(value AS UNIQUEIDENTIFIER) FROM STRING_SPLIT(@Replicas, ','))";
 
         var command = StoreCommand.Create(sql);
-        for (var i = 0; i < replicas.Count; i++)
-            command.AddParameter($"@Replica{i}", replicas[i].AsGuid);
+        command.AddParameter("@Replicas", string.Join(",", liveReplicas.Select(r => r.AsGuid)));
         return command;
     }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -675,6 +675,54 @@ public class SqlGenerator(string tablePrefix)
         return command;
     }
 
+    public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        var replicas = liveReplicas.ToList();
+        var notInClause = replicas.Count == 0
+            ? ""
+            : $" AND Replica NOT IN ({replicas.Select((_, i) => $"@Replica{i}").StringJoin(", ")})";
+        var sql = @$"
+            SELECT Id, Position
+            FROM {tablePrefix}_Messages
+            WHERE Replica IS NOT NULL{notInClause}
+            ORDER BY Position;";
+
+        var command = StoreCommand.Create(sql);
+        for (var i = 0; i < replicas.Count; i++)
+            command.AddParameter($"@Replica{i}", replicas[i].AsGuid);
+        return command;
+    }
+
+    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(SqlDataReader reader)
+    {
+        var result = new List<Tuple<StoredId, long>>();
+        while (await reader.ReadAsync())
+        {
+            var id = reader.GetGuid(0).ToStoredId();
+            var position = reader.GetInt64(1);
+            result.Add(Tuple.Create(id, position));
+        }
+
+        return result;
+    }
+
+    public StoreCommand SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var positionsList = positions.ToList();
+        var sql = @$"
+            UPDATE {tablePrefix}_Messages
+            SET Replica = @NewReplica
+            WHERE Position IN ({positionsList.Select((_, i) => $"@Position{i}").StringJoin(", ")}) AND Replica = @ExpectedReplica";
+
+        var command = StoreCommand.Create(sql);
+        command.AddParameter("@NewReplica", newReplica.AsGuid);
+        for (var i = 0; i < positionsList.Count; i++)
+            command.AddParameter($"@Position{i}", positionsList[i]);
+        command.AddParameter("@ExpectedReplica", expectedReplica.AsGuid);
+
+        return command;
+    }
+
     public async Task<Dictionary<StoredId, List<(byte[] content, long position, Guid? replica)>>> ReadStoredIdsMessages(SqlDataReader reader)
     {
         var messages = new Dictionary<StoredId, List<(byte[] content, long position, Guid? replica)>>();

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -678,14 +678,10 @@ public class SqlGenerator(string tablePrefix)
     public StoreCommand GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         var replicas = liveReplicas.ToList();
-        var notInClause = replicas.Count == 0
-            ? ""
-            : $" AND Replica NOT IN ({replicas.Select((_, i) => $"@Replica{i}").StringJoin(", ")})";
         var sql = @$"
             SELECT Id, Position
             FROM {tablePrefix}_Messages
-            WHERE Replica IS NOT NULL{notInClause}
-            ORDER BY Position;";
+            WHERE Replica NOT IN ({replicas.Select((_, i) => $"@Replica{i}").StringJoin(", ")})";
 
         var command = StoreCommand.Create(sql);
         for (var i = 0; i < replicas.Count; i++)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -693,14 +693,14 @@ public class SqlGenerator(string tablePrefix)
         return command;
     }
 
-    public async Task<List<Tuple<StoredId, long>>> ReadStoredIdAndPositions(SqlDataReader reader)
+    public async Task<List<StoredIdAndPosition>> ReadStoredIdAndPositions(SqlDataReader reader)
     {
-        var result = new List<Tuple<StoredId, long>>();
+        var result = new List<StoredIdAndPosition>();
         while (await reader.ReadAsync())
         {
             var id = reader.GetGuid(0).ToStoredId();
             var position = reader.GetInt64(1);
-            result.Add(Tuple.Create(id, position));
+            result.Add(new StoredIdAndPosition(id, position));
         }
 
         return result;

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -702,16 +702,14 @@ public class SqlGenerator(string tablePrefix)
 
     public StoreCommand SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
     {
-        var positionsList = positions.ToList();
         var sql = @$"
             UPDATE {tablePrefix}_Messages
             SET Replica = @NewReplica
-            WHERE Position IN ({positionsList.Select((_, i) => $"@Position{i}").StringJoin(", ")}) AND Replica = @ExpectedReplica";
+            WHERE Position IN (SELECT CAST(value AS BIGINT) FROM STRING_SPLIT(@Positions, ',')) AND Replica = @ExpectedReplica";
 
         var command = StoreCommand.Create(sql);
         command.AddParameter("@NewReplica", newReplica.AsGuid);
-        for (var i = 0; i < positionsList.Count; i++)
-            command.AddParameter($"@Position{i}", positionsList[i]);
+        command.AddParameter("@Positions", string.Join(",", positions));
         command.AddParameter("@ExpectedReplica", expectedReplica.AsGuid);
 
         return command;

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -221,7 +221,7 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)
     {
         await using var conn = await CreateConnection();
         await using var cmd = _sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToSqlCommand(conn);

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -33,7 +33,7 @@ public class SqlServerMessageStore : IMessageStore
         CREATE TABLE {_tablePrefix}_Messages (
             Position BIGINT IDENTITY(1,1) PRIMARY KEY,
             Id UNIQUEIDENTIFIER,
-            Replica UNIQUEIDENTIFIER NULL,
+            Replica UNIQUEIDENTIFIER NOT NULL,
             Content VARBINARY(MAX)
         );
         CREATE INDEX {_tablePrefix}_Messages_Id ON {_tablePrefix}_Messages (Id);";

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -221,6 +221,26 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
+    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    {
+        await using var conn = await CreateConnection();
+        await using var cmd = _sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToSqlCommand(conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        return await _sqlGenerator.ReadStoredIdAndPositions(reader);
+    }
+
+    public async Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica)
+    {
+        var positionsList = positions.ToList();
+        if (positionsList.Count == 0)
+            return;
+
+        await using var conn = await CreateConnection();
+        await using var command = _sqlGenerator.SetReplica(positionsList, newReplica, expectedReplica).ToSqlCommand(conn);
+        await command.ExecuteNonQueryAsync();
+    }
+
     public static StoredMessage ConvertToStoredMessage(byte[] content, long position, Guid? replica)
     {
         var arrs = BinaryPacker.Split(content, expectedPieces: 5);

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -221,7 +221,7 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
+    public async Task<List<StoredIdAndPosition>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas)
     {
         await using var conn = await CreateConnection();
         await using var cmd = _sqlGenerator.GetCrashedReplicaMessages(liveReplicas).ToSqlCommand(conn);


### PR DESCRIPTION
## Summary

Adds two methods to `IMessageStore` to support re-distributing messages stranded by crashed replicas:

```csharp
Task<List<Tuple<StoredId, long>>> GetCrashedReplicaMessages(IEnumerable<ReplicaId> liveReplicas);
Task SetReplica(IEnumerable<long> positions, ReplicaId newReplica, ReplicaId expectedReplica);
```

- **`GetCrashedReplicaMessages`** returns the `(StoredId, position)` identifiers of undelivered messages whose owning replica is **not** in the supplied live-replica set — i.e. messages stranded by a replica that is no longer alive. It returns just the identifiers (not full `StoredMessage` content), since the caller only needs them to hand off to `SetReplica`.
- **`SetReplica`** bulk-reassigns the messages at the given `positions` to `newReplica`, guarded by `expectedReplica` (optimistic concurrency) so a concurrent takeover/delivery is not clobbered. `position` is the global identity PK in every store, so keying on positions alone is unambiguous.

## Changes

- **Interface** (`Core/.../Messaging/IMessageStore.cs`)
- **Implementations**: `InMemoryFunctionStore`, `PostgreSqlMessageStore`, `MariaDbMessageStore`, `SqlServerMessageStore` (+ each store's `SqlGenerator`). Each `GetCrashedReplicaMessages` selects only `id, position` via a lightweight `ReadStoredIdAndPositions` reader.
- **Tests** added to the shared `MessageStoreTests` template (run against all four stores):
  - `CrashedReplicaMessagesAreFetched` — only messages owned by crashed replicas are returned.
  - `MessageReplicaCanBeReassigned` — positions owned by the expected replica are reassigned; one owned by a different replica is left untouched (verifies the `expectedReplica` guard).

## Testing

`GetCrashedReplicaMessages` / `SetReplica` tests pass on all stores:

- In-memory: 2/2
- PostgreSQL: 2/2
- SqlServer: 2/2
- MariaDB: 2/2