### PR TITLE
CI: start db container before build so it warms up during build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,9 +33,9 @@ jobs:
         - uses: actions/setup-dotnet@v5
           with:
             dotnet-version: '10.0.x'
-        - run: dotnet build Cleipnir.ResilientFunctions.sln
         - if: matrix.compose-service != ''
           run: docker compose up -d ${{ matrix.compose-service }}
+        - run: dotnet build Cleipnir.ResilientFunctions.sln
         - if: matrix.compose-service != ''
           run: dotnet run --project ./Stores/EnsureDatabaseConnections/EnsureDatabaseConnections.csproj --no-build -- ${{ matrix.db-name }}
         - run: dotnet test ./${{ matrix.test-project }} --no-build --logger "console;verbosity=detailed"


### PR DESCRIPTION
## Summary

Swaps the order of the `docker compose up` and `dotnet build` steps in the CI workflow so the database container starts **before** the build, letting it warm up in parallel with the build instead of only afterwards.

New step order per matrix job:
1. `docker compose up -d <service>` — DB container starts warming up
2. `dotnet build` — overlaps with DB startup
3. `EnsureDatabaseConnections` — retries until the DB is reachable
4. `dotnet test`

## Why

The database (the SqlServer container in particular) can take a while to become reachable. Previously the build ran first, then the container started cold, so the build time was wasted serially before the DB even began starting. Overlapping them shaves the DB startup off the critical path and makes the DB more likely to be ready by the time tests run.

`EnsureDatabaseConnections` still gates the tests via its internal retry loop, so behaviour is unchanged — this is purely a timing/ordering improvement.