### PR TITLE
Simplify GetMessagesForReplica to List<StoredMessages> and add ignorePositions

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
@@ -125,4 +125,8 @@ public class MessageStoreTests :  TestTemplates.MessageStoreTests
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1269,4 +1269,46 @@ public abstract class MessageStoreTests
         afterFlow2.Single(m => m.Position == bPosition).Replica.ShouldBe(newReplica);
         afterFlow2.Single(m => m.Position == cPosition).Replica.ShouldBe(otherReplica);
     }
+
+    public abstract Task GetMessagesForReplicaExcludesIgnoredPositions();
+    protected async Task GetMessagesForReplicaExcludesIgnoredPositions(Task<IFunctionStore> functionStoreTask)
+    {
+        var functionStore = await functionStoreTask;
+        var messageStore = functionStore.MessageStore;
+        var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
+
+        var replica = ReplicaId.NewId();
+        var otherReplica = ReplicaId.NewId();
+
+        var flow1 = TestStoredId.Create();
+        var flow2 = TestStoredId.Create();
+
+        // idle flows -> the stored replica falls back to the publishing replica we provide
+        await messageStore.AppendMessage(flow1, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        await messageStore.AppendMessage(flow1, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        await messageStore.AppendMessage(flow2, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        // owned by a different replica -> must never be returned
+        await messageStore.AppendMessage(flow2, new StoredMessage("d".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: otherReplica));
+
+        // no positions ignored -> all of the replica's messages, grouped by flow and ordered by position
+        var all = await messageStore.GetMessagesForReplica(replica, ignorePositions: []);
+        all.Count.ShouldBe(2);
+        var flow1Group = all.Single(g => g.StoredId == flow1);
+        var flow2Group = all.Single(g => g.StoredId == flow2);
+        flow1Group.Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["a", "b"]);
+        flow2Group.Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["c"]); // "d" belongs to otherReplica
+
+        var aPosition = flow1Group.Messages.Single(m => (string) m.DefaultDeserialize() == "a").Position;
+        var bPosition = flow1Group.Messages.Single(m => (string) m.DefaultDeserialize() == "b").Position;
+
+        // ignoring "b" leaves only "a" in flow1; flow2 is unaffected
+        var ignoredB = await messageStore.GetMessagesForReplica(replica, ignorePositions: [bPosition]);
+        ignoredB.Single(g => g.StoredId == flow1).Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["a"]);
+        ignoredB.Single(g => g.StoredId == flow2).Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["c"]);
+
+        // ignoring every position of a flow drops the whole group
+        var ignoredFlow1 = await messageStore.GetMessagesForReplica(replica, ignorePositions: [aPosition, bPosition]);
+        ignoredFlow1.ShouldAllBe(g => g.StoredId != flow1);
+        ignoredFlow1.Single(g => g.StoredId == flow2).Messages.Single().DefaultDeserialize().ShouldBe("c");
+    }
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -42,7 +42,7 @@ public class FlowsManager : IFlowsManager
                     flowState.Interrupt();
     }
 
-    public Task Push(IReadOnlyDictionary<StoredId, List<StoredMessage>> messagesByFlow)
+    public Task Push(IReadOnlyList<StoredMessages> messagesByFlow)
     {
         List<Task> tasks = new();
         lock (_lock)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Domain.Exceptions;
@@ -17,6 +19,11 @@ internal class MessageWatchdog
     private readonly TimeSpan _checkFrequency;
     private readonly TimeSpan _delayStartUp;
     private readonly UtcNow _utcNow;
+
+    // Positions already pushed to this replica's flows. Passed as ignore-set so messages are not re-delivered
+    // on subsequent ticks. Version 1: ever-growing - to be refined once the QueueManager reports the positions
+    // it has persisted into its effects.
+    private readonly HashSet<long> _pushedPositions = new();
 
     public MessageWatchdog(
         IMessageStore messageStore,
@@ -51,9 +58,15 @@ internal class MessageWatchdog
 
                 // Messages destined for flows currently owned by this replica (replica = COALESCE(owner, publisher)).
                 // FlowsManager.Push delivers only to live flows; entries for non-live flows are ignored.
-                var messagesByFlow = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId);
-                if (messagesByFlow.Count > 0)
-                    await _flowsManager.Push(messagesByFlow);
+                var messageGroups = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId, _pushedPositions.ToList());
+                if (messageGroups.Count > 0)
+                {
+                    foreach (var group in messageGroups)
+                        foreach (var message in group.Messages)
+                            _pushedPositions.Add(message.Position);
+
+                    await _flowsManager.Push(messageGroups);
+                }
 
                 var timeElapsed = _utcNow() - now;
                 var delay = (_checkFrequency - timeElapsed).RoundUpToZero();

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -28,9 +28,11 @@ public interface IMessageStore
 
     /// <summary>
     /// Returns the undelivered messages whose replica equals the provided replica, grouped by target flow.
+    /// Messages at any of the <paramref name="ignorePositions"/> are excluded - the MessageWatchdog passes the
+    /// positions it has already pushed so they are not re-delivered on subsequent ticks.
     /// Used by the MessageWatchdog to push messages to live flows owned by this replica.
     /// </summary>
-    Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId);
+    Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions);
 
     /// <summary>
     /// Returns the (flow, position) identifiers of the undelivered messages owned by a replica that is no

--- a/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Helpers;
@@ -12,6 +13,7 @@ public record StoredMessage(byte[] MessageContent, byte[] MessageType, long Posi
 }
 
 public record StoredIdAndMessage(StoredId StoredId, StoredMessage StoredMessage);
+public record StoredMessages(StoredId StoredId, List<StoredMessage> Messages);
 public static class StoredIdAndMessageExtensions
 {
     public static StoredIdAndMessage ToStoredIdAndMessage(this StoredMessage storedMessage, StoredId storedId) 

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -668,23 +668,24 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         return dict;
     }
 
-    public Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         lock (_sync)
         {
-            var dict = new Dictionary<StoredId, List<StoredMessage>>();
+            var ignore = ignorePositions.ToHashSet();
+            var result = new List<StoredMessages>();
             foreach (var (storedId, messages) in _messages)
             {
                 var list = messages
                     .OrderBy(kv => kv.Key)
-                    .Where(kv => kv.Value.Replica == replicaId)
+                    .Where(kv => kv.Value.Replica == replicaId && !ignore.Contains(kv.Key))
                     .Select(kv => kv.Value with { Position = kv.Key })
                     .ToList();
                 if (list.Count > 0)
-                    dict[storedId] = list;
+                    result.Add(new StoredMessages(storedId, list));
             }
 
-            return dict.ToTask();
+            return result.ToTask();
         }
     }
 

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
@@ -120,4 +120,8 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -192,22 +192,23 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = _sqlGenerator
-            .GetMessagesForReplica(replicaId)
+            .GetMessagesForReplica(replicaId, ignorePositions)
             .ToSqlCommand(conn);
 
         await using var reader = await command.ExecuteReaderAsync();
 
         var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
 
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -660,15 +660,15 @@ public class SqlGenerator(string tablePrefix)
         return messages;
     }
 
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         var sql = @$"
             SELECT id, position, content, replica
             FROM {tablePrefix}_messages
-            WHERE replica = ?
+            WHERE replica = ? AND FIND_IN_SET(position, ?) = 0
             ORDER BY position;";
 
-        return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N") ]);
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N"), string.Join(",", ignorePositions) ]);
     }
 
     public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
@@ -121,4 +121,8 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -195,18 +195,19 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await CreateConnection();
-        await using var command = sqlGenerator.GetMessagesForReplica(replicaId).ToNpgsqlCommand(conn);
+        await using var command = sqlGenerator.GetMessagesForReplica(replicaId, ignorePositions).ToNpgsqlCommand(conn);
 
         await using var reader = await command.ExecuteReaderAsync();
         var messages = await sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -584,15 +584,15 @@ public class SqlGenerator(string tablePrefix)
         return storeCommand;
     }
 
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         var sql = @$"
             SELECT id, position, content, replica
             FROM {tablePrefix}_messages
-            WHERE replica = $1
+            WHERE replica = $1 AND position != ALL($2)
             ORDER BY position;";
 
-        return StoreCommand.Create(sql, values: [ replicaId.AsGuid ]);
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid, ignorePositions.ToArray() ]);
     }
 
     public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
@@ -121,4 +121,8 @@ public class MessageStoreTests :  Cleipnir.ResilientFunctions.Tests.Messaging.Te
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -662,16 +662,17 @@ public class SqlGenerator(string tablePrefix)
     }
 
     private string? _getMessagesForReplicaSql;
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         _getMessagesForReplicaSql ??= @$"
             SELECT Id, Position, Content, Replica
             FROM {tablePrefix}_Messages
-            WHERE Replica = @Replica
+            WHERE Replica = @Replica AND Position NOT IN (SELECT CAST(value AS BIGINT) FROM STRING_SPLIT(@IgnorePositions, ','))
             ORDER BY Position;";
 
         var command = StoreCommand.Create(_getMessagesForReplicaSql);
         command.AddParameter("@Replica", replicaId.AsGuid);
+        command.AddParameter("@IgnorePositions", ignorePositions.Count > 0 ? string.Join(",", ignorePositions) : "-1");
         return command;
     }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -205,18 +205,19 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await CreateConnection();
-        await using var cmd = _sqlGenerator.GetMessagesForReplica(replicaId).ToSqlCommand(conn);
+        await using var cmd = _sqlGenerator.GetMessagesForReplica(replicaId, ignorePositions).ToSqlCommand(conn);
         await using var reader = await cmd.ExecuteReaderAsync();
 
         var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }


### PR DESCRIPTION
## What

Simplifies `IMessageStore.GetMessagesForReplica` and lays the foundation for de-duplicating watchdog message delivery.

**Before**
```csharp
Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId);
```
**After**
```csharp
Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions);
```

- New `record StoredMessages(StoredId StoredId, List<StoredMessage> Messages)` replaces the dictionary return shape.
- `ignorePositions` excludes already-handled positions so they aren't re-delivered on subsequent ticks.
- `FlowsManager.Push` now takes `IReadOnlyList<StoredMessages>`.

## MessageWatchdog (version 1)

The watchdog keeps an **ever-growing** `HashSet<long>` of positions it has already pushed and passes it as `ignorePositions` each tick. This is a deliberate first step — it will be refined once the `QueueManager` reports the positions it has persisted into its effects, which will bound the set.

## Store implementations

Each store filters the ignore-set with a **stable, parameterized** query so the plan is reused regardless of set size (no plan-cache churn from inlined literals):

| Store | Filter |
|-------|--------|
| PostgreSQL | `position != ALL($2)` (bound array param) |
| SQL Server | `Position NOT IN (SELECT CAST(value AS BIGINT) FROM STRING_SPLIT(@IgnorePositions, ','))` |
| MariaDB | `FIND_IN_SET(position, ?) = 0` |
| InMemory | `HashSet` lookup |

The empty case is handled per dialect (Postgres empty array; SQL Server `-1` sentinel in the *parameter* to avoid an empty-string `CAST`; MariaDB `FIND_IN_SET(_, '') = 0` is naturally a no-op).

## Tests

Adds `GetMessagesForReplicaExcludesIgnoredPositions` to the shared `MessageStoreTests` template, run across **all four stores** (InMemory, PostgreSQL, MariaDB, SQL Server). Covers:
- empty ignore-set returns every message for the replica, grouped by flow and ordered by position;
- messages owned by a different replica are never returned;
- ignoring a position drops just that message;
- ignoring all of a flow's positions drops the whole group.

All four pass against the real databases.