### PR TITLE
Collapse IMessageStore to a single AppendMessages entry point

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/InMemoryTests/MessageStoreTests.cs
@@ -125,4 +125,8 @@ public class MessageStoreTests :  TestTemplates.MessageStoreTests
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/MessageStoreTestExtensions.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/MessageStoreTestExtensions.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Storage;
+
+namespace Cleipnir.ResilientFunctions.Messaging;
+
+public static class MessageStoreTestExtensions
+{
+    /// <summary>
+    /// Test convenience for appending a single message - forwards to <see cref="IMessageStore.AppendMessages"/>.
+    /// </summary>
+    public static Task AppendMessage(this IMessageStore messageStore, StoredId storedId, StoredMessage storedMessage)
+        => messageStore.AppendMessages([new StoredIdAndMessage(storedId, storedMessage)]);
+}

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessageStoreTests.cs
@@ -1269,4 +1269,46 @@ public abstract class MessageStoreTests
         afterFlow2.Single(m => m.Position == bPosition).Replica.ShouldBe(newReplica);
         afterFlow2.Single(m => m.Position == cPosition).Replica.ShouldBe(otherReplica);
     }
+
+    public abstract Task GetMessagesForReplicaExcludesIgnoredPositions();
+    protected async Task GetMessagesForReplicaExcludesIgnoredPositions(Task<IFunctionStore> functionStoreTask)
+    {
+        var functionStore = await functionStoreTask;
+        var messageStore = functionStore.MessageStore;
+        var stringType = typeof(string).SimpleQualifiedName().ToUtf8Bytes();
+
+        var replica = ReplicaId.NewId();
+        var otherReplica = ReplicaId.NewId();
+
+        var flow1 = TestStoredId.Create();
+        var flow2 = TestStoredId.Create();
+
+        // idle flows -> the stored replica falls back to the publishing replica we provide
+        await messageStore.AppendMessage(flow1, new StoredMessage("a".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        await messageStore.AppendMessage(flow1, new StoredMessage("b".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        await messageStore.AppendMessage(flow2, new StoredMessage("c".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: replica));
+        // owned by a different replica -> must never be returned
+        await messageStore.AppendMessage(flow2, new StoredMessage("d".ToJson().ToUtf8Bytes(), stringType, Position: 0, Replica: otherReplica));
+
+        // no positions ignored -> all of the replica's messages, grouped by flow and ordered by position
+        var all = await messageStore.GetMessagesForReplica(replica, ignorePositions: []);
+        all.Count.ShouldBe(2);
+        var flow1Group = all.Single(g => g.StoredId == flow1);
+        var flow2Group = all.Single(g => g.StoredId == flow2);
+        flow1Group.Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["a", "b"]);
+        flow2Group.Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["c"]); // "d" belongs to otherReplica
+
+        var aPosition = flow1Group.Messages.Single(m => (string) m.DefaultDeserialize() == "a").Position;
+        var bPosition = flow1Group.Messages.Single(m => (string) m.DefaultDeserialize() == "b").Position;
+
+        // ignoring "b" leaves only "a" in flow1; flow2 is unaffected
+        var ignoredB = await messageStore.GetMessagesForReplica(replica, ignorePositions: [bPosition]);
+        ignoredB.Single(g => g.StoredId == flow1).Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["a"]);
+        ignoredB.Single(g => g.StoredId == flow2).Messages.Select(m => (string) m.DefaultDeserialize()).ShouldBe(["c"]);
+
+        // ignoring every position of a flow drops the whole group
+        var ignoredFlow1 = await messageStore.GetMessagesForReplica(replica, ignorePositions: [aPosition, bPosition]);
+        ignoredFlow1.ShouldAllBe(g => g.StoredId != flow1);
+        ignoredFlow1.Single(g => g.StoredId == flow2).Messages.Single().DefaultDeserialize().ShouldBe("c");
+    }
 }

--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesTests.cs
@@ -361,16 +361,11 @@ public abstract class MessagesTests
         var serializer = DefaultSerializer.Instance;
         var messageStore = functionStore.MessageStore;
 
-        var messageWriter = new MessageWriter(storedId, messageStore, serializer, ReplicaId.NewId(), new NoOpFlowsManager());
+        var messageWriter = new MessageWriter(storedId, messageStore, serializer, ReplicaId.NewId());
         await messageWriter.AppendMessage("hello world", idempotencyKey: "key1", sender: "TestSender");
 
         var messages = await messageStore.GetMessages(storedId);
         messages.Count.ShouldBe(1);
         messages[0].Sender.ShouldBe("TestSender");
-    }
-
-    private sealed class NoOpFlowsManager : IFlowsManager
-    {
-        public Task Schedule(StoredId storedId) => Task.CompletedTask;
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManager.cs
@@ -42,7 +42,7 @@ public class FlowsManager : IFlowsManager
                     flowState.Interrupt();
     }
 
-    public Task Push(IReadOnlyDictionary<StoredId, List<StoredMessage>> messagesByFlow)
+    public Task Push(IReadOnlyList<StoredMessages> messagesByFlow)
     {
         List<Task> tasks = new();
         lock (_lock)

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -24,13 +24,12 @@ internal class InvocationHelper<TParam, TReturn>
     private readonly FlowType _flowType;
     private readonly StoredType _storedType;
     private readonly ReplicaId _replicaId;
-    private readonly IFlowsManager _flowsManager;
     private readonly ResultBusyWaiter<TReturn> _resultBusyWaiter;
     public UtcNow UtcNow { get; }
 
     private ISerializer Serializer { get; }
 
-    public InvocationHelper(FlowType flowType, StoredType storedType, ReplicaId replicaId, bool isParamlessFunction, SettingsWithDefaults settings, IFunctionStore functionStore, ShutdownCoordinator shutdownCoordinator, ISerializer serializer, UtcNow utcNow, bool clearChildren, IFlowsManager flowsManager)
+    public InvocationHelper(FlowType flowType, StoredType storedType, ReplicaId replicaId, bool isParamlessFunction, SettingsWithDefaults settings, IFunctionStore functionStore, ShutdownCoordinator shutdownCoordinator, ISerializer serializer, UtcNow utcNow, bool clearChildren)
     {
         _flowType = flowType;
         _isParamlessFunction = isParamlessFunction;
@@ -43,7 +42,6 @@ internal class InvocationHelper<TParam, TReturn>
         _storedType = storedType;
         _replicaId = replicaId;
         _functionStore = functionStore;
-        _flowsManager = flowsManager;
         _resultBusyWaiter = new ResultBusyWaiter<TReturn>(_functionStore, Serializer);
     }
 
@@ -206,9 +204,7 @@ internal class InvocationHelper<TParam, TReturn>
         var content = Serializer.Serialize(msg, msg.GetType());
         var type = Serializer.SerializeType(msg.GetType());
         var storedMessage = new StoredMessage(content, type, Position: 0, IdempotencyKey: $"FlowCompleted:{childId}", Replica: _replicaId);
-        var writtenReplica = await _functionStore.MessageStore.AppendMessage(parent, storedMessage);
-        if (writtenReplica == _replicaId)
-            await _functionStore.Interrupt(parent);
+        await _functionStore.MessageStore.AppendMessages([new StoredIdAndMessage(parent, storedMessage)]);
     }
 
     public async Task<RestartedFunction?> RestartFunction(StoredId flowId)
@@ -385,7 +381,7 @@ internal class InvocationHelper<TParam, TReturn>
     }
     
     public MessageWriter CreateMessageWriter(StoredId storedId)
-        => new MessageWriter(storedId, _functionStore.MessageStore, Serializer, _replicaId, _flowsManager);
+        => new MessageWriter(storedId, _functionStore.MessageStore, Serializer, _replicaId);
 
     public Effect CreateEffect(StoredId storedId, FlowId flowId, IReadOnlyList<StoredEffect> storedEffects, FlowTimeouts flowTimeouts, IStorageSession? storageSession, FlowState flowState)
     {

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Domain.Exceptions;
@@ -17,6 +19,11 @@ internal class MessageWatchdog
     private readonly TimeSpan _checkFrequency;
     private readonly TimeSpan _delayStartUp;
     private readonly UtcNow _utcNow;
+
+    // Positions already pushed to this replica's flows. Passed as ignore-set so messages are not re-delivered
+    // on subsequent ticks. Version 1: ever-growing - to be refined once the QueueManager reports the positions
+    // it has persisted into its effects.
+    private readonly HashSet<long> _pushedPositions = new();
 
     public MessageWatchdog(
         IMessageStore messageStore,
@@ -51,9 +58,15 @@ internal class MessageWatchdog
 
                 // Messages destined for flows currently owned by this replica (replica = COALESCE(owner, publisher)).
                 // FlowsManager.Push delivers only to live flows; entries for non-live flows are ignored.
-                var messagesByFlow = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId);
-                if (messagesByFlow.Count > 0)
-                    await _flowsManager.Push(messagesByFlow);
+                var messageGroups = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId, _pushedPositions.ToList());
+                if (messageGroups.Count > 0)
+                {
+                    foreach (var group in messageGroups)
+                        foreach (var message in group.Messages)
+                            _pushedPositions.Add(message.Position);
+
+                    await _flowsManager.Push(messageGroups);
+                }
 
                 var timeElapsed = _utcNow() - now;
                 var delay = (_checkFrequency - timeElapsed).RoundUpToZero();

--- a/Core/Cleipnir.ResilientFunctions/Domain/ExistingMessages.cs
+++ b/Core/Cleipnir.ResilientFunctions/Domain/ExistingMessages.cs
@@ -55,9 +55,8 @@ public class ExistingMessages
     {
         var json = _serializer.Serialize(message, message.GetType());
         var type = _serializer.SerializeType(message.GetType());
-        await _messageStore.AppendMessage(
-            _storedId, new StoredMessage(json, type, Position: 0, Replica: ReplicaId.Empty, IdempotencyKey: idempotencyKey)
-        );
+        var storedMessage = new StoredMessage(json, type, Position: 0, Replica: ReplicaId.Empty, IdempotencyKey: idempotencyKey);
+        await _messageStore.AppendMessages([new StoredIdAndMessage(_storedId, storedMessage)]);
 
         // Invalidate cache so it will be re-fetched with correct positions
         _receivedMessages = null;

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -246,8 +246,7 @@ public class FunctionsRegistry : IDisposable
                 _shutdownCoordinator,
                 serializer,
                 _settings.UtcNow,
-                settings?.ClearChildrenAfterCapture ?? true,
-                _flowsManager
+                settings?.ClearChildrenAfterCapture ?? true
             );
             var invoker = new Invoker<TParam, TReturn>(
                 flowType,
@@ -283,8 +282,7 @@ public class FunctionsRegistry : IDisposable
                 storedType,
                 _functionStore,
                 serializer,
-                ClusterInfo.ReplicaId,
-                _flowsManager
+                ClusterInfo.ReplicaId
             );
 
             var registration = new FuncRegistration<TParam, TReturn>(
@@ -331,8 +329,7 @@ public class FunctionsRegistry : IDisposable
                 _shutdownCoordinator,
                 serializer,
                 _settings.UtcNow,
-                settings?.ClearChildrenAfterCapture ?? true,
-                _flowsManager
+                settings?.ClearChildrenAfterCapture ?? true
             );
             var invoker = new Invoker<Unit, Unit>(
                 flowType,
@@ -368,8 +365,7 @@ public class FunctionsRegistry : IDisposable
                 storedType,
                 _functionStore,
                 serializer,
-                ClusterInfo.ReplicaId,
-                _flowsManager
+                ClusterInfo.ReplicaId
             );
 
             var registration = new ParamlessRegistration(
@@ -416,8 +412,7 @@ public class FunctionsRegistry : IDisposable
                 _shutdownCoordinator,
                 serializer,
                 _settings.UtcNow,
-                settings?.ClearChildrenAfterCapture ?? true,
-                _flowsManager
+                settings?.ClearChildrenAfterCapture ?? true
             );
             var rActionInvoker = new Invoker<TParam, Unit>(
                 flowType,
@@ -453,8 +448,7 @@ public class FunctionsRegistry : IDisposable
                 storedType,
                 _functionStore,
                 serializer,
-                ClusterInfo.ReplicaId,
-                _flowsManager
+                ClusterInfo.ReplicaId
             );
             var registration = new ActionRegistration<TParam>(
                 flowType,

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -10,11 +10,12 @@ public interface IMessageStore
     Task Initialize();
 
     /// <summary>
-    /// Appends a message to the target flow and returns the replica written to the message row
-    /// (the target flow's current owner, or the publishing replica when the target is not executing).
-    /// The target flow is scheduled to run immediately when it is suspended/postponed.
+    /// Appends the messages to their target flows and interrupts each distinct target so it runs
+    /// immediately and consumes the message (the interrupt is the suspend-race guard and watchdog
+    /// backstop, so the message is never lost even when the target suspends concurrently or is owned
+    /// by another replica). Each message row is written with the target flow's current owner, or the
+    /// publishing replica when the target is not executing.
     /// </summary>
-    Task<ReplicaId> AppendMessage(StoredId storedId, StoredMessage storedMessage);
     Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages);
 
     Task<bool> ReplaceMessage(StoredId storedId, long position, StoredMessage storedMessage);

--- a/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/IMessageStore.cs
@@ -28,9 +28,11 @@ public interface IMessageStore
 
     /// <summary>
     /// Returns the undelivered messages whose replica equals the provided replica, grouped by target flow.
+    /// Messages at any of the <paramref name="ignorePositions"/> are excluded - the MessageWatchdog passes the
+    /// positions it has already pushed so they are not re-delivered on subsequent ticks.
     /// Used by the MessageWatchdog to push messages to live flows owned by this replica.
     /// </summary>
-    Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId);
+    Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions);
 
     /// <summary>
     /// Returns the (flow, position) identifiers of the undelivered messages owned by a replica that is no

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriter.cs
@@ -1,26 +1,18 @@
 ﻿using System.Threading.Tasks;
-using Cleipnir.ResilientFunctions.CoreRuntime;
 using Cleipnir.ResilientFunctions.CoreRuntime.Serialization;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.Messaging;
 
-public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer, ReplicaId publisherReplica, IFlowsManager flowsManager)
+public class MessageWriter(StoredId storedIdId, IMessageStore messageStore, ISerializer eventSerializer, ReplicaId publisherReplica)
 {
     public async Task AppendMessage<TMessage>(TMessage message, string? idempotencyKey = null, string? sender = null, string? receiver = null) where TMessage : class
     {
         var eventJson = eventSerializer.Serialize(message, message.GetType());
         var eventType = eventSerializer.SerializeType(message.GetType());
 
-        var writtenReplica = await messageStore.AppendMessage(
-            storedIdId,
-            new StoredMessage(eventJson, eventType, Position: 0, Replica: publisherReplica, IdempotencyKey: idempotencyKey, Sender: sender, Receiver: receiver)
-        );
-
-        // The message fell back to (or is owned by) this replica - schedule the target so it runs and consumes
-        // the message. Targets owned by another replica are delivered by that replica's MessageWatchdog.
-        if (writtenReplica == publisherReplica)
-            await flowsManager.Schedule(storedIdId);
+        var storedMessage = new StoredMessage(eventJson, eventType, Position: 0, Replica: publisherReplica, IdempotencyKey: idempotencyKey, Sender: sender, Receiver: receiver);
+        await messageStore.AppendMessages([new StoredIdAndMessage(storedIdId, storedMessage)]);
     }
 }

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageWriters.cs
@@ -14,31 +14,28 @@ public class MessageWriters
     private readonly IFunctionStore _functionStore;
     private readonly ISerializer _serializer;
     private readonly ReplicaId _publisherReplica;
-    private readonly IFlowsManager _flowsManager;
 
     public MessageWriters(
         StoredType storedType,
         IFunctionStore functionStore,
         ISerializer serializer,
-        ReplicaId publisherReplica,
-        IFlowsManager flowsManager)
+        ReplicaId publisherReplica)
     {
         _storedType = storedType;
         _functionStore = functionStore;
         _serializer = serializer;
         _publisherReplica = publisherReplica;
-        _flowsManager = flowsManager;
     }
 
     public MessageWriter For(FlowInstance instance)
     {
         var storedId = StoredId.Create(_storedType, instance.Value);
-        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica, _flowsManager);
+        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica);
     }
 
     internal MessageWriter For(StoredId storedId)
     {
-        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica, _flowsManager);
+        return new MessageWriter(storedId, _functionStore.MessageStore, _serializer, _publisherReplica);
     }
 
     public async Task AppendMessages(IReadOnlyList<BatchedMessage> messages)

--- a/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/StoredMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Helpers;
@@ -12,6 +13,7 @@ public record StoredMessage(byte[] MessageContent, byte[] MessageType, long Posi
 }
 
 public record StoredIdAndMessage(StoredId StoredId, StoredMessage StoredMessage);
+public record StoredMessages(StoredId StoredId, List<StoredMessage> Messages);
 public static class StoredIdAndMessageExtensions
 {
     public static StoredIdAndMessage ToStoredIdAndMessage(this StoredMessage storedMessage, StoredId storedId) 

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -668,23 +668,24 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
         return dict;
     }
 
-    public Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         lock (_sync)
         {
-            var dict = new Dictionary<StoredId, List<StoredMessage>>();
+            var ignore = ignorePositions.ToHashSet();
+            var result = new List<StoredMessages>();
             foreach (var (storedId, messages) in _messages)
             {
                 var list = messages
                     .OrderBy(kv => kv.Key)
-                    .Where(kv => kv.Value.Replica == replicaId)
+                    .Where(kv => kv.Value.Replica == replicaId && !ignore.Contains(kv.Key))
                     .Select(kv => kv.Value with { Position = kv.Key })
                     .ToList();
                 if (list.Count > 0)
-                    dict[storedId] = list;
+                    result.Add(new StoredMessages(storedId, list));
             }
 
-            return dict.ToTask();
+            return result.ToTask();
         }
     }
 

--- a/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
+++ b/Core/Cleipnir.ResilientFunctions/Storage/InMemoryFunctionStore.cs
@@ -581,27 +581,20 @@ public class InMemoryFunctionStore : IFunctionStore, IMessageStore
     
     #region MessageStore
 
-    public virtual Task<ReplicaId> AppendMessage(StoredId storedId, StoredMessage storedMessage)
-    {
-        lock (_sync)
-        {
-            if (!_messages.ContainsKey(storedId))
-                _messages[storedId] = new Dictionary<long, StoredMessage>();
-
-            var flowOwner = _states.TryGetValue(storedId, out var state) ? state.Owner : null;
-            var replica = flowOwner ?? storedMessage.Replica;
-            var messages = _messages[storedId];
-            messages[_nextMessagePosition++] = storedMessage with { Replica = replica };
-
-            return Task.FromResult(replica);
-        }
-    }
-
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         foreach (var (storedId, storedMessage) in messages)
         {
-            await AppendMessage(storedId, storedMessage);
+            lock (_sync)
+            {
+                if (!_messages.TryGetValue(storedId, out var flowMessages))
+                    flowMessages = _messages[storedId] = new Dictionary<long, StoredMessage>();
+
+                var flowOwner = _states.TryGetValue(storedId, out var state) ? state.Owner : null;
+                var replica = flowOwner ?? storedMessage.Replica;
+                flowMessages[_nextMessagePosition++] = storedMessage with { Replica = replica };
+            }
+
             await Interrupt(storedId);
         }
     }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB.Tests/Messaging/MessageStoreTests.cs
@@ -120,4 +120,8 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -58,12 +58,17 @@ public class MariaDbMessageStore : IMessageStore
         var appendMessagesCommand = _sqlGenerator.AppendMessages(messages);
         var interruptsCommand = _sqlGenerator.Interrupt(storedIds);
 
-        var command = StoreCommand.Merge(appendMessagesCommand, interruptsCommand);
-
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        await using var sqlCommand = command.ToSqlCommand(conn);
 
-        await sqlCommand.ExecuteNonQueryAsync();
+        // The append and the interrupt are executed as separate commands - not merged into one - so the
+        // insert's locks are released before the interrupt UPDATE runs. Merging them caused lock contention
+        // that deadlocked tight message-exchange loops (e.g. ping-pong) where two executing flows interrupt
+        // each other.
+        await using var appendCommand = appendMessagesCommand.ToSqlCommand(conn);
+        await appendCommand.ExecuteNonQueryAsync();
+
+        await using var interruptCommand = interruptsCommand.ToSqlCommand(conn);
+        await interruptCommand.ExecuteNonQueryAsync();
     }
 
     private string? _replaceMessageSql;

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -48,25 +48,6 @@ public class MariaDbMessageStore : IMessageStore
     }
 
 
-    public async Task<ReplicaId> AppendMessage(StoredId storedId, StoredMessage storedMessage)
-    {
-        var (messageContent, messageType, _, replica, idempotencyKey, sender, receiver) = storedMessage;
-        var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
-
-        var sql = @$"
-            INSERT INTO {_tablePrefix}_messages (id, replica, content)
-            VALUES (?, COALESCE((SELECT owner FROM {_tablePrefix} WHERE id = ?), ?), ?)
-            RETURNING replica;";
-
-        await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
-        await using var command = new MySqlCommand(sql, conn);
-        command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
-        command.Parameters.Add(new() { Value = storedId.AsGuid.ToString("N") });
-        command.Parameters.Add(new() { Value = replica.AsGuid.ToString("N") });
-        command.Parameters.Add(new() { Value = content });
-        return ((string) (await command.ExecuteScalarAsync())!).ParseToReplicaId();
-    }
-
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         if (messages.Count == 0)

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/MariaDbMessageStore.cs
@@ -192,22 +192,23 @@ public class MariaDbMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await DatabaseHelper.CreateOpenConnection(_connectionString);
         await using var command = _sqlGenerator
-            .GetMessagesForReplica(replicaId)
+            .GetMessagesForReplica(replicaId, ignorePositions)
             .ToSqlCommand(conn);
 
         await using var reader = await command.ExecuteReaderAsync();
 
         var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
 
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }

--- a/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
+++ b/Stores/MariaDB/Cleipnir.ResilientFunctions.MariaDB/SqlGenerator.cs
@@ -660,15 +660,15 @@ public class SqlGenerator(string tablePrefix)
         return messages;
     }
 
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         var sql = @$"
             SELECT id, position, content, replica
             FROM {tablePrefix}_messages
-            WHERE replica = ?
+            WHERE replica = ? AND FIND_IN_SET(position, ?) = 0
             ORDER BY position;";
 
-        return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N") ]);
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid.ToString("N"), string.Join(",", ignorePositions) ]);
     }
 
     public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL.Tests/Messaging/MessageStoreTests.cs
@@ -121,4 +121,8 @@ public class MessageStoreTests :  ResilientFunctions.Tests.Messaging.TestTemplat
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -195,18 +195,19 @@ public class PostgreSqlMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await CreateConnection();
-        await using var command = sqlGenerator.GetMessagesForReplica(replicaId).ToNpgsqlCommand(conn);
+        await using var command = sqlGenerator.GetMessagesForReplica(replicaId, ignorePositions).ToNpgsqlCommand(conn);
 
         await using var reader = await command.ExecuteReaderAsync();
         var messages = await sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/PostgreSqlMessageStore.cs
@@ -57,30 +57,6 @@ public class PostgreSqlMessageStore : IMessageStore
         await command.ExecuteNonQueryAsync();
     }
 
-    private string? _appendMessageSql;
-    public async Task<ReplicaId> AppendMessage(StoredId storedId, StoredMessage storedMessage)
-    {
-        _appendMessageSql ??= @$"
-            INSERT INTO {tablePrefix}_messages (id, replica, content)
-            VALUES ($1, COALESCE((SELECT owner FROM {tablePrefix} WHERE id = $1), $2), $3)
-            RETURNING replica;";
-
-        var content = BinaryPacker.Pack(
-            storedMessage.MessageContent,
-            storedMessage.MessageType,
-            storedMessage.IdempotencyKey?.ToUtf8Bytes(),
-            storedMessage.Sender?.ToUtf8Bytes(),
-            storedMessage.Receiver?.ToUtf8Bytes()
-        );
-
-        await using var conn = await CreateConnection();
-        await using var command = StoreCommand
-            .Create(_appendMessageSql, values: [storedId.AsGuid, storedMessage.Replica.AsGuid, content])
-            .ToNpgsqlCommand(conn);
-        var result = await command.ExecuteScalarAsync();
-        return ((Guid) result!).ToReplicaId();
-    }
-
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         if (messages.Count == 0)

--- a/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
+++ b/Stores/PostgreSQL/Cleipnir.ResilientFunctions.PostgreSQL/SqlGenerator.cs
@@ -584,15 +584,15 @@ public class SqlGenerator(string tablePrefix)
         return storeCommand;
     }
 
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         var sql = @$"
             SELECT id, position, content, replica
             FROM {tablePrefix}_messages
-            WHERE replica = $1
+            WHERE replica = $1 AND position != ALL($2)
             ORDER BY position;";
 
-        return StoreCommand.Create(sql, values: [ replicaId.AsGuid ]);
+        return StoreCommand.Create(sql, values: [ replicaId.AsGuid, ignorePositions.ToArray() ]);
     }
 
     public StoreCommand GetCrashedReplicaMessages(IReadOnlySet<ReplicaId> liveReplicas)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer.Tests/Messaging/MessageStoreTests.cs
@@ -121,4 +121,8 @@ public class MessageStoreTests :  Cleipnir.ResilientFunctions.Tests.Messaging.Te
     [TestMethod]
     public override Task MessageReplicaCanBeReassigned()
         => MessageReplicaCanBeReassigned(FunctionStoreFactory.Create());
+
+    [TestMethod]
+    public override Task GetMessagesForReplicaExcludesIgnoredPositions()
+        => GetMessagesForReplicaExcludesIgnoredPositions(FunctionStoreFactory.Create());
 }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlGenerator.cs
@@ -662,16 +662,17 @@ public class SqlGenerator(string tablePrefix)
     }
 
     private string? _getMessagesForReplicaSql;
-    public StoreCommand GetMessagesForReplica(ReplicaId replicaId)
+    public StoreCommand GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         _getMessagesForReplicaSql ??= @$"
             SELECT Id, Position, Content, Replica
             FROM {tablePrefix}_Messages
-            WHERE Replica = @Replica
+            WHERE Replica = @Replica AND Position NOT IN (SELECT CAST(value AS BIGINT) FROM STRING_SPLIT(@IgnorePositions, ','))
             ORDER BY Position;";
 
         var command = StoreCommand.Create(_getMessagesForReplicaSql);
         command.AddParameter("@Replica", replicaId.AsGuid);
+        command.AddParameter("@IgnorePositions", ignorePositions.Count > 0 ? string.Join(",", ignorePositions) : "-1");
         return command;
     }
 

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -53,24 +53,6 @@ public class SqlServerMessageStore : IMessageStore
         await command.ExecuteNonQueryAsync();
     }
 
-    public async Task<ReplicaId> AppendMessage(StoredId storedId, StoredMessage storedMessage)
-    {
-        var (messageContent, messageType, _, replica, idempotencyKey, sender, receiver) = storedMessage;
-        var content = BinaryPacker.Pack(messageContent, messageType, idempotencyKey?.ToUtf8Bytes(), sender?.ToUtf8Bytes(), receiver?.ToUtf8Bytes());
-
-        var sql = @$"
-            INSERT INTO {_tablePrefix}_Messages (Id, Replica, Content)
-            OUTPUT inserted.Replica
-            VALUES (@Id, COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id), @Replica), @Content);";
-
-        await using var conn = await CreateConnection();
-        await using var command = new SqlCommand(sql, conn);
-        command.Parameters.AddWithValue("@Id", storedId.AsGuid);
-        command.Parameters.AddWithValue("@Replica", replica.AsGuid);
-        command.Parameters.AddWithValue("@Content", content);
-        return ((Guid) (await command.ExecuteScalarAsync())!).ToReplicaId();
-    }
-
     public async Task AppendMessages(IReadOnlyList<StoredIdAndMessage> messages)
     {
         if (messages.Count == 0)

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -205,18 +205,19 @@ public class SqlServerMessageStore : IMessageStore
         return storedMessages;
     }
 
-    public async Task<Dictionary<StoredId, List<StoredMessage>>> GetMessagesForReplica(ReplicaId replicaId)
+    public async Task<List<StoredMessages>> GetMessagesForReplica(ReplicaId replicaId, IReadOnlyList<long> ignorePositions)
     {
         await using var conn = await CreateConnection();
-        await using var cmd = _sqlGenerator.GetMessagesForReplica(replicaId).ToSqlCommand(conn);
+        await using var cmd = _sqlGenerator.GetMessagesForReplica(replicaId, ignorePositions).ToSqlCommand(conn);
         await using var reader = await cmd.ExecuteReaderAsync();
 
         var messages = await _sqlGenerator.ReadStoredIdsMessages(reader);
-        var storedMessages = new Dictionary<StoredId, List<StoredMessage>>();
+        var storedMessages = new List<StoredMessages>();
         foreach (var id in messages.Keys)
-            storedMessages[id] = messages[id]
-                .Select(m => ConvertToStoredMessage(m.content, m.position, m.replica))
-                .ToList();
+            storedMessages.Add(new StoredMessages(
+                id,
+                messages[id].Select(m => ConvertToStoredMessage(m.content, m.position, m.replica)).ToList()
+            ));
 
         return storedMessages;
     }

--- a/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
+++ b/Stores/SqlServer/Cleipnir.ResilientFunctions.SqlServer/SqlServerMessageStore.cs
@@ -75,9 +75,7 @@ public class SqlServerMessageStore : IMessageStore
             INSERT INTO {_tablePrefix}_Messages
                 (Id, Replica, Content)
             VALUES
-                 {messages.Select((_, i) => $"(@Id{i}, COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id{i}), @Replica{i}), @Content{i})").StringJoin($",{Environment.NewLine}")};
-
-            {interuptsSql.Sql}";
+                 {messages.Select((_, i) => $"(@Id{i}, COALESCE((SELECT Owner FROM {_tablePrefix} WHERE Id = @Id{i}), @Replica{i}), @Content{i})").StringJoin($",{Environment.NewLine}")};";
 
         await using var command = new SqlCommand(sql, conn);
         for (var i = 0; i < messages.Count; i++)
@@ -88,10 +86,14 @@ public class SqlServerMessageStore : IMessageStore
             command.Parameters.AddWithValue($"@Replica{i}", replica.AsGuid);
             command.Parameters.AddWithValue($"@Content{i}", content);
         }
-        foreach (var (value, name) in interuptsSql.Parameters)
-            command.Parameters.AddWithValue(name, value);
-
         await command.ExecuteNonQueryAsync();
+
+        // The interrupt is executed as a separate command - not merged into the insert above - so the
+        // insert's locks are released before the interrupt UPDATE runs. Merging them caused lock contention
+        // that deadlocked tight message-exchange loops (e.g. ping-pong) where two executing flows interrupt
+        // each other (SQL Server's lock-wait is unbounded, so it hung indefinitely).
+        await using var interruptCommand = interuptsSql.ToSqlCommand(conn);
+        await interruptCommand.ExecuteNonQueryAsync();
     }
 
     private string? _replaceMessageSql;


### PR DESCRIPTION
## Summary

Removes `IMessageStore.AppendMessage` (singular) and routes every message append through `AppendMessages`, collapsing the message store to a single append entry point.

The two production callers that consumed `AppendMessage`'s returned `ReplicaId` — `MessageWriter.AppendMessage` and `InvocationHelper.PublishCompletionMessageToParent` — used it only to decide whether to interrupt/schedule the target flow. Since `AppendMessages` already interrupts every distinct target, that conditional becomes unconditional. This matches the documented intent that the interrupt is the suspend-race guard and watchdog backstop *"even when the target is owned by another replica"* — the singular path previously skipped it for cross-replica targets.

### Behavioral note
Appending a message now **always** interrupts the target flow:
- `MessageWriter`: previously interrupted only when the message landed on the publisher's replica; now always (safe superset — cross-replica delivery is unchanged via the owning replica's `MessageWatchdog`).
- `ExistingMessages.Append`: previously never interrupted; now does.

### Changes
- **Interface**: drop `Task<ReplicaId> AppendMessage(StoredId, StoredMessage)` from `IMessageStore`.
- **Stores**: remove the duplicate single-row INSERT from PostgreSQL/SqlServer/MariaDB; `InMemoryFunctionStore` inlines the per-message append into `AppendMessages`.
- **Callers**: `MessageWriter`, `InvocationHelper`, `ExistingMessages` now call `AppendMessages([...])`.
- **Dead-plumbing cleanup**: the singular path was the only reason `IFlowsManager` was threaded into `MessageWriter` → `MessageWriters` → `InvocationHelper`; that dependency (and the `FunctionsRegistry` wiring) is removed.
- **Tests**: a test-only `AppendMessage` extension forwards to `AppendMessages`, so existing message-store tests keep exercising the single-append path.

### Lock-contention fix (SqlServer + MariaDB)
Routing single appends through `AppendMessages` initially **merged** the INSERT and the interrupt UPDATE into one command/connection in the SqlServer and MariaDB stores. Holding the insert's locks while the interrupt UPDATE ran deadlocked tight message-exchange loops (ping-pong) where two executing flows interrupt each other — SQL Server's unbounded lock-wait hung indefinitely. Fixed by executing the interrupt as a **separate command after the insert** (matching the previous append-then-schedule design). PostgreSQL already runs them as separate auto-committing batch commands and is unaffected.

## Testing
- In-memory suite: **518/518 passed**
- PostgreSQL store suite: **380/380 passed**
- MariaDB store suite: **380/380 passed**
- SqlServer store suite: **379 passed**; `PingPongMessagesCanBeExchangedMultipleTimes` flaky-hangs only under full-suite load. Verified this hang is **pre-existing on `main`/base** (the base commit hangs on the same test in the same way) — it is the known load-dependent idle-target-restart race, not introduced here. The test passes reliably when run on its own on this branch.

## Note
This branch also carries the previously unmerged commit `151de337` (*Simplify GetMessagesForReplica to List<StoredMessages> and add ignorePositions*), per the decision to stack rather than split into a separate PR.