### PR TITLE
Introduce FlowsManagers to scope each FlowsManager to a single flow type

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManagers.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/FlowsManagers.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Messaging;
+using Cleipnir.ResilientFunctions.Storage;
+
+namespace Cleipnir.ResilientFunctions.CoreRuntime;
+
+/// <summary>
+/// Holds one <see cref="FlowsManager"/> per <see cref="StoredType"/> so each manager is concerned with a single
+/// flow type only. Registration obtains its type's manager through <see cref="GetOrCreate"/>; the watchdogs call
+/// the routing methods below, which group the incoming ids by <see cref="StoredId.Type"/> and dispatch to the
+/// matching per-type manager. Ids for types not registered on this replica are ignored.
+/// </summary>
+public class FlowsManagers
+{
+    private readonly Dictionary<StoredType, FlowsManager> _managers = new();
+    private readonly IFunctionStore _functionStore;
+    private readonly Lock _lock = new();
+
+    public FlowsManagers(IFunctionStore functionStore) => _functionStore = functionStore;
+
+    public FlowsManager GetOrCreate(StoredType storedType)
+    {
+        lock (_lock)
+        {
+            if (_managers.TryGetValue(storedType, out var existing))
+                return existing;
+
+            return _managers[storedType] = new FlowsManager(_functionStore);
+        }
+    }
+
+    private FlowsManager? TryGet(StoredType storedType)
+    {
+        lock (_lock)
+            return _managers.GetValueOrDefault(storedType);
+    }
+
+    public Task Push(IReadOnlyList<StoredMessages> messagesByFlow)
+    {
+        List<Task> tasks = new();
+        foreach (var group in messagesByFlow.GroupBy(m => m.StoredId.Type))
+            if (TryGet(group.Key) is { } manager)
+                tasks.Add(manager.Push(group.ToList()));
+
+        return Task.WhenAll(tasks);
+    }
+
+    public IReadOnlyList<StoredId> FilterOwned(IEnumerable<StoredId> ids)
+    {
+        var owned = new List<StoredId>();
+        foreach (var group in ids.GroupBy(id => id.Type))
+            if (TryGet(group.Key) is { } manager)
+                owned.AddRange(manager.FilterOwned(group.ToList()));
+
+        return owned;
+    }
+
+    public void Interrupt(IReadOnlyList<StoredId> ids)
+    {
+        foreach (var group in ids.GroupBy(id => id.Type))
+            TryGet(group.Key)?.Interrupt(group.ToList());
+    }
+}

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/InterruptedWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/InterruptedWatchdog.cs
@@ -10,7 +10,7 @@ namespace Cleipnir.ResilientFunctions.CoreRuntime.Watchdogs;
 internal class InterruptedWatchdog
 {
     private readonly IFunctionStore _functionStore;
-    private readonly FlowsManager _flowsManager;
+    private readonly FlowsManagers _flowsManagers;
     private readonly ShutdownCoordinator _shutdownCoordinator;
     private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
     private readonly TimeSpan _checkFrequency;
@@ -19,7 +19,7 @@ internal class InterruptedWatchdog
 
     public InterruptedWatchdog(
         IFunctionStore functionStore,
-        FlowsManager flowsManager,
+        FlowsManagers flowsManagers,
         ShutdownCoordinator shutdownCoordinator,
         UnhandledExceptionHandler unhandledExceptionHandler,
         TimeSpan checkFrequency,
@@ -27,7 +27,7 @@ internal class InterruptedWatchdog
         UtcNow utcNow)
     {
         _functionStore = functionStore;
-        _flowsManager = flowsManager;
+        _flowsManagers = flowsManagers;
         _shutdownCoordinator = shutdownCoordinator;
         _unhandledExceptionHandler = unhandledExceptionHandler;
         _checkFrequency = checkFrequency;
@@ -47,11 +47,11 @@ internal class InterruptedWatchdog
                 var now = _utcNow();
 
                 var interrupted = await _functionStore.GetInterruptedFunctions();
-                var owned = _flowsManager.FilterOwned(interrupted);
+                var owned = _flowsManagers.FilterOwned(interrupted);
                 if (owned.Count > 0)
                 {
                     await _functionStore.ResetInterrupted(owned);
-                    _flowsManager.Interrupt(owned);
+                    _flowsManagers.Interrupt(owned);
                 }
 
                 var timeElapsed = _utcNow() - now;

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
@@ -12,7 +12,7 @@ namespace Cleipnir.ResilientFunctions.CoreRuntime.Watchdogs;
 internal class MessageWatchdog
 {
     private readonly IMessageStore _messageStore;
-    private readonly FlowsManager _flowsManager;
+    private readonly FlowsManagers _flowsManagers;
     private readonly ClusterInfo _clusterInfo;
     private readonly ShutdownCoordinator _shutdownCoordinator;
     private readonly UnhandledExceptionHandler _unhandledExceptionHandler;
@@ -27,7 +27,7 @@ internal class MessageWatchdog
 
     public MessageWatchdog(
         IMessageStore messageStore,
-        FlowsManager flowsManager,
+        FlowsManagers flowsManagers,
         ClusterInfo clusterInfo,
         ShutdownCoordinator shutdownCoordinator,
         UnhandledExceptionHandler unhandledExceptionHandler,
@@ -36,7 +36,7 @@ internal class MessageWatchdog
         UtcNow utcNow)
     {
         _messageStore = messageStore;
-        _flowsManager = flowsManager;
+        _flowsManagers = flowsManagers;
         _clusterInfo = clusterInfo;
         _shutdownCoordinator = shutdownCoordinator;
         _unhandledExceptionHandler = unhandledExceptionHandler;
@@ -57,7 +57,8 @@ internal class MessageWatchdog
                 var now = _utcNow();
 
                 // Messages destined for flows currently owned by this replica (replica = COALESCE(owner, publisher)).
-                // FlowsManager.Push delivers only to live flows; entries for non-live flows are ignored.
+                // FlowsManagers.Push routes each group to its flow type's manager and delivers only to live
+                // flows; entries for non-live flows (or unregistered types) are ignored.
                 var messageGroups = await _messageStore.GetMessagesForReplica(_clusterInfo.ReplicaId, _pushedPositions.ToList());
                 if (messageGroups.Count > 0)
                 {
@@ -65,7 +66,7 @@ internal class MessageWatchdog
                         foreach (var message in group.Messages)
                             _pushedPositions.Add(message.Position);
 
-                    await _flowsManager.Push(messageGroups);
+                    await _flowsManagers.Push(messageGroups);
                 }
 
                 var timeElapsed = _utcNow() - now;

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -33,7 +33,7 @@ public class FunctionsRegistry : IDisposable
     private readonly ReplicaWatchdog _replicaWatchdog;
     private readonly InterruptedWatchdog _interruptedWatchdog;
     private readonly MessageWatchdog _messageWatchdog;
-    private readonly FlowsManager _flowsManager;
+    private readonly FlowsManagers _flowsManagers;
 
     public FunctionsRegistry(IFunctionStore functionStore, Settings? settings = null)
     {
@@ -42,7 +42,7 @@ public class FunctionsRegistry : IDisposable
         _shutdownCoordinator = new ShutdownCoordinator();
         _settings = SettingsWithDefaults.Default.Merge(settings);
         var utcNow = _settings.UtcNow;
-        _flowsManager = new FlowsManager(_functionStore);
+        _flowsManagers = new FlowsManagers(_functionStore);
 
         ClusterInfo = new ClusterInfo(ReplicaId.NewId());
         
@@ -66,7 +66,7 @@ public class FunctionsRegistry : IDisposable
 
         _interruptedWatchdog = new InterruptedWatchdog(
             _functionStore,
-            _flowsManager,
+            _flowsManagers,
             _shutdownCoordinator,
             _settings.UnhandledExceptionHandler,
             _settings.WatchdogCheckFrequency,
@@ -76,7 +76,7 @@ public class FunctionsRegistry : IDisposable
 
         _messageWatchdog = new MessageWatchdog(
             _functionStore.MessageStore,
-            _flowsManager,
+            _flowsManagers,
             ClusterInfo,
             _shutdownCoordinator,
             _settings.UnhandledExceptionHandler,
@@ -255,7 +255,7 @@ public class FunctionsRegistry : IDisposable
                 invocationHelper,
                 settingsWithDefaults.UnhandledExceptionHandler,
                 ClusterInfo.ReplicaId,
-                _flowsManager
+                _flowsManagers.GetOrCreate(storedType)
             );
 
             WatchDogsFactory.CreateAndStart(
@@ -338,7 +338,7 @@ public class FunctionsRegistry : IDisposable
                 invocationHelper,
                 settingsWithDefaults.UnhandledExceptionHandler,
                 ClusterInfo.ReplicaId,
-                _flowsManager
+                _flowsManagers.GetOrCreate(storedType)
             );
 
             WatchDogsFactory.CreateAndStart(
@@ -421,7 +421,7 @@ public class FunctionsRegistry : IDisposable
                 invocationHelper,
                 settingsWithDefaults.UnhandledExceptionHandler,
                 ClusterInfo.ReplicaId,
-                _flowsManager
+                _flowsManagers.GetOrCreate(storedType)
             );
 
             WatchDogsFactory.CreateAndStart(


### PR DESCRIPTION
## Summary
Adds a `FlowsManagers` type holding a `Dictionary<StoredType, FlowsManager>`, so each `FlowsManager` is concerned with a single flow type only while the message watchdog can still push messages through to the specific manager.

## What changed
- **New `FlowsManagers`** (`CoreRuntime/FlowsManagers.cs`):
  - `GetOrCreate(StoredType)` — registration obtains its flow type's manager.
  - `Push` / `FilterOwned` / `Interrupt` — routing facade that groups incoming ids by `StoredId.Type` and dispatches to the matching per-type `FlowsManager`. Ids whose type isn't registered on this replica are skipped, mirroring the old "not in dict → ignore" behaviour. Dictionary access is guarded by a `Lock` (registration writes while watchdogs read concurrently).
- **`FunctionsRegistry`** — single `_flowsManager` → `_flowsManagers`; each registration passes `_flowsManagers.GetOrCreate(storedType)` to its `Invoker`.
- **`MessageWatchdog`** — takes `FlowsManagers`; `Push(messageGroups)` now routes per flow type.
- **`InterruptedWatchdog`** — takes `FlowsManagers`; `FilterOwned` + `Interrupt` route per type.

## Deliberately unchanged
- `FlowsManager` keeps its constructor and methods (still keyed by `StoredId`, now scoped to one type), so the existing `new FlowsManager(functionStore)` test sites keep compiling.
- `Invoker` still receives a `FlowsManager` — just the per-type instance.
- `IFlowsManager.Schedule` has no callers yet, so no routing wrapper was added for it.

## Testing
- Core library and core test project build clean (0 warnings / 0 errors).