### PR TITLE
Route QueueManager message fetch through MessageWatchdog

### DIFF
--- a/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
+++ b/Core/Cleipnir.ResilientFunctions.Tests/Messaging/TestTemplates/MessagesSubscriptionTests.cs
@@ -574,7 +574,7 @@ public abstract class MessagesSubscriptionTests
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
-                    functionStore.MessageStore,
+                    functionStore.MessageStore.GetMessages,
                     exceptionThrowingSerializer,
                     workflow.Effect,
                     flowState,
@@ -638,7 +638,7 @@ public abstract class MessagesSubscriptionTests
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
-                    functionStore.MessageStore,
+                    functionStore.MessageStore.GetMessages,
                     DefaultSerializer.Instance,
                     workflow.Effect,
                     flowState,
@@ -700,7 +700,7 @@ public abstract Task PullEnvelopeReturnsEnvelopeWithReceiverAndSender();
                 var queueManager = new QueueManager(
                     workflow.FlowId,
                     workflow.StoredId,
-                    functionStore.MessageStore,
+                    functionStore.MessageStore.GetMessages,
                     DefaultSerializer.Instance,
                     workflow.Effect,
                     flowState,

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Invocation/InvocationHelper.cs
@@ -27,11 +27,12 @@ internal class InvocationHelper<TParam, TReturn>
     private readonly ReplicaId _replicaId;
     private readonly ResultBusyWaiter<TReturn> _resultBusyWaiter;
     private readonly IMessageClearer _messageClearer;
+    private readonly MessageFetcher _fetchMessages;
     public UtcNow UtcNow { get; }
 
     private ISerializer Serializer { get; }
 
-    public InvocationHelper(FlowType flowType, StoredType storedType, ReplicaId replicaId, bool isParamlessFunction, SettingsWithDefaults settings, IFunctionStore functionStore, ShutdownCoordinator shutdownCoordinator, ISerializer serializer, UtcNow utcNow, bool clearChildren, IMessageClearer messageClearer)
+    public InvocationHelper(FlowType flowType, StoredType storedType, ReplicaId replicaId, bool isParamlessFunction, SettingsWithDefaults settings, IFunctionStore functionStore, ShutdownCoordinator shutdownCoordinator, ISerializer serializer, UtcNow utcNow, bool clearChildren, IMessageClearer messageClearer, MessageFetcher fetchMessages)
     {
         _flowType = flowType;
         _isParamlessFunction = isParamlessFunction;
@@ -45,6 +46,7 @@ internal class InvocationHelper<TParam, TReturn>
         _replicaId = replicaId;
         _functionStore = functionStore;
         _messageClearer = messageClearer;
+        _fetchMessages = fetchMessages;
         _resultBusyWaiter = new ResultBusyWaiter<TReturn>(_functionStore, Serializer);
     }
 
@@ -413,7 +415,7 @@ internal class InvocationHelper<TParam, TReturn>
     public ExistingMessages CreateExistingMessages(FlowId flowId) => new(MapToStoredId(flowId), _functionStore.MessageStore, Serializer);
 
     public QueueManager CreateQueueManager(FlowId flowId, StoredId storedId, Effect effect, FlowState flowState, FlowTimeouts timeouts, UnhandledExceptionHandler unhandledExceptionHandler)
-        => new(flowId, storedId, _functionStore.MessageStore, Serializer, effect, flowState, unhandledExceptionHandler, timeouts, UtcNow, _settings, _messageClearer);
+        => new(flowId, storedId, _fetchMessages, Serializer, effect, flowState, unhandledExceptionHandler, timeouts, UtcNow, _settings, _messageClearer);
 
     public StoredId MapToStoredId(FlowId flowId) => StoredId.Create(_storedType, flowId.Instance.Value);
     

--- a/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
+++ b/Core/Cleipnir.ResilientFunctions/CoreRuntime/Watchdogs/MessageWatchdog.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Cleipnir.ResilientFunctions.Domain;
 using Cleipnir.ResilientFunctions.Domain.Exceptions;
 using Cleipnir.ResilientFunctions.Helpers;
 using Cleipnir.ResilientFunctions.Messaging;
+using Cleipnir.ResilientFunctions.Storage;
 
 namespace Cleipnir.ResilientFunctions.CoreRuntime.Watchdogs;
 
@@ -19,6 +21,16 @@ internal class MessageWatchdog(
     TimeSpan delayStartUp,
     UtcNow utcNow)
 {
+    /// <summary>
+    /// On-demand fetch for a single flow, used by its <see cref="Queuing.QueueManager"/> instead of reaching into
+    /// the message store directly - so all <see cref="IMessageStore"/> access stays owned by the watchdog. Unlike
+    /// the poll loop below this does not consult the clearer's pushed-set: the caller passes its own already-fetched
+    /// positions as <paramref name="skipPositions"/>, which keeps the subscribe-time and restart-from-replay fetch
+    /// behaviour identical to the previous in-QueueManager fetch.
+    /// </summary>
+    public Task<IReadOnlyList<StoredMessage>> FetchMessages(StoredId storedId, IReadOnlyList<long> skipPositions)
+        => messageStore.GetMessages(storedId, skipPositions);
+
     public async Task Start()
     {
         await Task.Delay(delayStartUp);

--- a/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
+++ b/Core/Cleipnir.ResilientFunctions/FunctionsRegistry.cs
@@ -255,7 +255,8 @@ public class FunctionsRegistry : IDisposable
                 serializer,
                 _settings.UtcNow,
                 settings?.ClearChildrenAfterCapture ?? true,
-                _messageClearer
+                _messageClearer,
+                _messageWatchdog.FetchMessages
             );
             var invoker = new Invoker<TParam, TReturn>(
                 flowType,
@@ -339,7 +340,8 @@ public class FunctionsRegistry : IDisposable
                 serializer,
                 _settings.UtcNow,
                 settings?.ClearChildrenAfterCapture ?? true,
-                _messageClearer
+                _messageClearer,
+                _messageWatchdog.FetchMessages
             );
             var invoker = new Invoker<Unit, Unit>(
                 flowType,
@@ -423,7 +425,8 @@ public class FunctionsRegistry : IDisposable
                 serializer,
                 _settings.UtcNow,
                 settings?.ClearChildrenAfterCapture ?? true,
-                _messageClearer
+                _messageClearer,
+                _messageWatchdog.FetchMessages
             );
             var rActionInvoker = new Invoker<TParam, Unit>(
                 flowType,

--- a/Core/Cleipnir.ResilientFunctions/Messaging/MessageFetcher.cs
+++ b/Core/Cleipnir.ResilientFunctions/Messaging/MessageFetcher.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cleipnir.ResilientFunctions.Storage;
+
+namespace Cleipnir.ResilientFunctions.Messaging;
+
+/// <summary>
+/// Fetches the not-yet-skipped messages for a single flow. Implemented by the MessageWatchdog so that all
+/// IMessageStore access is owned by the watchdog: the QueueManager pulls on-demand through this delegate
+/// instead of reaching into the message store itself.
+/// </summary>
+public delegate Task<IReadOnlyList<StoredMessage>> MessageFetcher(StoredId storedId, IReadOnlyList<long> skipPositions);

--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -24,7 +24,7 @@ internal class QueueManager : IDisposable
 
     private readonly FlowId _flowId;
     private readonly StoredId _storedId;
-    private readonly IMessageStore _messageStore;
+    private readonly MessageFetcher _fetchMessages;
     private readonly ISerializer _serializer;
     private readonly Effect _effect;
     private readonly FlowState _flowState;
@@ -49,7 +49,7 @@ internal class QueueManager : IDisposable
     public QueueManager(
         FlowId flowId,
         StoredId storedId,
-        IMessageStore messageStore,
+        MessageFetcher fetchMessages,
         ISerializer serializer,
         Effect effect,
         FlowState flowState,
@@ -63,7 +63,7 @@ internal class QueueManager : IDisposable
     {
         _flowId = flowId;
         _storedId = storedId;
-        _messageStore = messageStore;
+        _fetchMessages = fetchMessages;
         _serializer = serializer;
         _effect = effect;
         _flowState = flowState;
@@ -199,7 +199,7 @@ internal class QueueManager : IDisposable
             lock (_lock)
                 skipPositions = _fetchedPositions.ToList();
 
-            var messages = await _messageStore.GetMessages(_storedId, skipPositions);
+            var messages = await _fetchMessages(_storedId, skipPositions);
             await ProcessMessages(messages);
         }
         finally


### PR DESCRIPTION
## Summary
Moves all `IMessageStore.GetMessages` access out of `QueueManager` and into `MessageWatchdog`, so the watchdog owns every store read (on-demand single-flow fetch + the existing replica poll loop).

- New `MessageFetcher` delegate `(StoredId, IReadOnlyList<long> skip) -> Task<IReadOnlyList<StoredMessage>>` (signature-identical to `IMessageStore.GetMessages`).
- `QueueManager` drops its `IMessageStore` dependency for a `MessageFetcher`; `FetchAndNotify` calls the delegate instead of the store.
- `MessageWatchdog.FetchMessages` is the production target; wired via `FunctionsRegistry` -> `InvocationHelper` -> `CreateQueueManager`.
- The 3 hand-rolled `new QueueManager(...)` tests pass `functionStore.MessageStore.GetMessages` (method-group -> delegate).

## Design note
The on-demand fetch passes **only** the QueueManager's per-instance fetched positions as the skip set and deliberately does **not** consult the clearer's global pushed-set. Routing it through the global set would suppress re-delivery to a restarted/suspended flow on the same replica (the watchdog marks every fetched position pushed before routing, and `FlowsManager.Push` drops non-live flows) and hang it. Per-instance skip keeps subscribe-time and restart-from-replay behaviour identical to the previous in-QueueManager fetch.

## Testing
- Full solution builds clean.
- All 459 in-memory tests pass (incl. suspension / postponed / subscription / restart-replay).
- Store-backed tests pending (Docker was down locally) — running them now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)