### PR TITLE
Make ProcessMessages synchronous now that it no longer awaits

### DIFF
--- a/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
+++ b/Core/Cleipnir.ResilientFunctions/Queuing/QueueManager.cs
@@ -136,7 +136,7 @@ internal class QueueManager : IDisposable
             if (_thrownException != null)
                 return;
 
-            await ProcessMessages(messages);
+            ProcessMessages(messages);
         }
         finally
         {
@@ -200,7 +200,7 @@ internal class QueueManager : IDisposable
                 skipPositions = _fetchedPositions.ToList();
 
             var messages = await _messageStore.GetMessages(_storedId, skipPositions);
-            await ProcessMessages(messages);
+            ProcessMessages(messages);
         }
         finally
         {
@@ -211,7 +211,7 @@ internal class QueueManager : IDisposable
 
     // Caller must hold _fetchSemaphore. Deserializes, dedups by idempotency-key and by already-fetched
     // position (so pushes are idempotent), and stages messages for delivery.
-    private async Task ProcessMessages(IReadOnlyList<StoredMessage> messages)
+    private void ProcessMessages(IReadOnlyList<StoredMessage> messages)
     {
         foreach (var (messageContent, messageType, position, _, idempotencyKey, sender, receiver) in messages)
         {


### PR DESCRIPTION
## Summary

Follow-up to #176. The dedup branch in `QueueManager.ProcessMessages` no longer awaits `_messageClearer.Clear` — it stages the position and persists it to the `DeliveredPositionsId` effect instead — so `ProcessMessages` has no remaining `await`s.

This changes it from `async Task` to `void` and drops the `await` at both call sites (`Push`, `FetchAndNotify`). Both callers remain `async` for the fetch-semaphore wait and the message-store call.

## Notes

The "make synchronous" cleanup was originally meant to ride along on #176 but was dropped when that PR squash-merged before its second commit synced. This PR redoes it on top of current `main`.

## Testing

- `dotnet build` of the core project passes (0 warnings, 0 errors) — confirms no "async method lacks await" warnings, i.e. both callers genuinely still need to be async.